### PR TITLE
Add action to automatically assign issues

### DIFF
--- a/.github/workflows/auto_assign_action.yml
+++ b/.github/workflows/auto_assign_action.yml
@@ -10,4 +10,4 @@ jobs:
       - name: 'Auto-assign issue'
         uses: pozil/auto-assign-issue@v1.1.0
         with:
-          assignees: jdemelo-splunk,pzhou-splunk,rgil-splunk
+          assignees: jdemelo,pzhou-splunk,rgil-splunk

--- a/.github/workflows/auto_assign_action.yml
+++ b/.github/workflows/auto_assign_action.yml
@@ -1,0 +1,13 @@
+name: Auto Assign Issues
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Auto-assign issue'
+        uses: pozil/auto-assign-issue@v1.1.0
+        with:
+          assignees: jdemelo-splunk,pzhou-splunk,rgil-splunk


### PR DESCRIPTION
Add default assignees for issues. These will likely be mostly requests to create new app repos (since app specific issues will go to their respective repos).

Unfortunately, I can't properly test this before merging it... However, the action is largely copied directly from the snippet provided by the author: https://github.com/marketplace/actions/auto-assign-issue