### PR TITLE
Updating start-release template

### DIFF
--- a/workflow-templates/start-release.yml
+++ b/workflow-templates/start-release.yml
@@ -1,5 +1,6 @@
 name: Start Release
 on:
+  workflow_dispatch:
   push:
     tags:
       - '*-beta*'

--- a/workflow-templates/start-release.yml
+++ b/workflow-templates/start-release.yml
@@ -1,5 +1,8 @@
 name: Start Release
-on: workflow_dispatch
+on:
+  push:
+    tags:
+      - '*-beta*'
 jobs:
   start-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Notes
- Updating the workflow template for start-release to be triggered on the beta-release tags created by the build jobs


### Testing
- Updated the workflow file on https://github.com/splunk-soar-connectors/exampleapp and verified the action is triggered only when tags including `-beta` are pushed