### PR TITLE
Adding workflow template for reviewing app releases

### DIFF
--- a/workflow-templates/review-release.properties.json
+++ b/workflow-templates/review-release.properties.json
@@ -1,0 +1,8 @@
+{
+    "name": "Review Release",
+    "description": "Determines whether a given app release is automatically approved for Splunkbase upload or if it requires manual approval.",
+    "iconName": "shield_green_icon",
+    "categories": [
+        "Python"
+    ]
+}

--- a/workflow-templates/review-release.yml
+++ b/workflow-templates/review-release.yml
@@ -46,7 +46,7 @@ jobs:
     if: always() && needs.manual_review.result == 'failure'
     runs-on: ubuntu-latest
     steps:
-      - uses: 'phantomcyber/dev-cicd-tools/github-actions/resume-release@review-release'
+      - uses: 'phantomcyber/dev-cicd-tools/github-actions/resume-release@main'
         with:
           approved: false
           task_token: ${{ github.event.inputs.task_token }}

--- a/workflow-templates/review-release.yml
+++ b/workflow-templates/review-release.yml
@@ -1,0 +1,54 @@
+name: Review Release
+concurrency:
+  group: app-release
+  cancel-in-progress: true
+permissions:
+  contents: read
+  id-token: write
+  statuses: read
+on:
+  workflow_dispatch:
+    inputs:
+      task_token:
+        description: 'StepFunction task token'
+        required: true
+
+jobs:
+  review_release:
+    runs-on: ubuntu-latest
+    outputs:
+      manual_review_required: ${{ steps.review_release.outputs.manual_review_required }}
+    steps:
+      - id: review_release
+        uses: 'phantomcyber/dev-cicd-tools/github-actions/review-release@main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+  manual_review:
+    needs: [review_release]
+    if: needs.review_release.outputs.manual_review_required == 'true'
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - run: exit 0
+  approve_release:
+    needs: [review_release, manual_review]
+    if: always() && (needs.manual_review.result == 'success' || (needs.review_release.result == 'success' && needs.manual_review.result == 'skipped'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 'phantomcyber/dev-cicd-tools/github-actions/resume-release@main'
+        with:
+          approved: true
+          task_token: ${{ github.event.inputs.task_token }}
+          iam_role_arn: ${{ secrets.RESUME_RELEASE_ROLE_ARN }}
+          aws_region: us-west-1
+  reject_release:
+    needs: [manual_review]
+    if: always() && needs.manual_review.result == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 'phantomcyber/dev-cicd-tools/github-actions/resume-release@review-release'
+        with:
+          approved: false
+          task_token: ${{ github.event.inputs.task_token }}
+          iam_role_arn: ${{ secrets.RESUME_RELEASE_ROLE_ARN }}
+          aws_region: us-west-1


### PR DESCRIPTION
### Notes
- Adding a workflow template for reviewing app releases
- This workflow uses the actions setup in https://github.com/phantomcyber/dev-cicd-tools/pull/47
- The `review-release` action in dev-cicd-tools is first called to determine if manual approval is required for the release
- If manual review is required, the `manual_review` job is triggered under an [environment](https://docs.github.com/en/actions/using-jobs/using-environments-for-jobs) named `prod` that is assumed to exist in the given repo - this will request manual approval from a configured list of users/teams
-  Lastly, the `resume-release` action in dev-cicd-tools is called from either the `approve_release` or `reject_release` job depending on the approval status of the release

### Testing
- [workflow run](https://github.com/splunk-soar-connectors/exampleapp/actions/runs/2448934470) approving a release
- [workflow run](https://github.com/splunk-soar-connectors/exampleapp/actions/runs/2448921609) rejecting a release
- [workflow run](https://github.com/splunk-soar-connectors/exampleapp/actions/runs/2449785375) intentionally causing `review-release` to fail (no data sent back to StepFunctions)