### PR TITLE
Add Paul to default issue assignee list

### DIFF
--- a/.github/workflows/auto_assign_action.yml
+++ b/.github/workflows/auto_assign_action.yml
@@ -10,4 +10,4 @@ jobs:
       - name: 'Auto-assign issue'
         uses: pozil/auto-assign-issue@v1.1.0
         with:
-          assignees: jdemelo,pzhou-splunk,rgil-splunk
+          assignees: jdemelo,paulnawat,pzhou-splunk,rgil-splunk


### PR DESCRIPTION
Add @paulnawat as a default assignee for new issues. Issues created on this repo are primarily requests for new repos.