### PR TITLE
Replace references of readme.html

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ Please ensure your pull request (PR) adheres to the following guidelines:
 
 #### Please check if your PR fulfills the following requirements:
 - [ ] Testing of all the changes has been performed (for bug fixes / features)
-- [ ] The readme.html has been reviewed and added / updated if needed (for bug fixes / features)
+- [ ] The manual_readme_content.md has been reviewed and added / updated if needed (for bug fixes / features)
 - [ ] Use the following format for the PR description: `<App Name>: <PR Type> - <PR Description>`
 - [ ] Provide release notes as part of the PR submission which describe high level points about the changes for the upcoming GA release.
 - [ ] Verify all checks are passing.
@@ -22,22 +22,22 @@ Please ensure your pull request (PR) adheres to the following guidelines:
 - [ ] Code style update (formatting, renaming)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Documentation
-- [ ] Other (please describe): 
+- [ ] Other (please describe):
 
 ## Security Considerations (REQUIRED)
-- [ ] If you are exposing any endpoints using a [REST handler](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers), 
-  please document them in the `readme.html`.
+- [ ] If you are exposing any endpoints using a [REST handler](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers),
+  please document them in the `manual_readme_content.md`.
 - [ ] If this is a new connector or you are adding new actions
-    - [ ] Please document in the `readme.html` all methods (eg, OAuth) used to authenticate 
+    - [ ] Please document in the `manual_readme_content.md` all methods (eg, OAuth) used to authenticate
       with the service that the connector is integrating with.
-    - [ ] If any actions are unable to run on SOAR Cloud, please document this in the `readme.html`.
+    - [ ] If any actions are unable to run on SOAR Cloud, please document this in the `manual_readme_content.md`.
 - [ ] Are you introducing any new cryptography modules? If yes, please elaborate their purpose:
-- [ ] Are you are accessing the file system? If yes, please verify that you are only accessing paths returned through 
+- [ ] Are you are accessing the file system? If yes, please verify that you are only accessing paths returned through
 the [Vault](https://docs.splunk.com/Documentation/SOARonprem/5.2.1/DevelopApps/AppDevAPIRef#Vault) API.
 - [ ] Are you are marking code to be ignored by Semgrep with [`nosemgrep`](https://semgrep.dev/docs/ignoring-files-folders-code/#ignoring-code-through-nosemgrep)?
 If yes, please provide justification in an additional comment next to the ignored code.
 
-  
+
 
 ## Release Notes (REQUIRED)
 - Provide release notes as part of the PR submission which describe high level points about the changes for the upcoming GA release.

--- a/workflow-templates/generate-doc.yml
+++ b/workflow-templates/generate-doc.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '*.json'
       - 'readme.html'
+      - 'manual_readme_content.md'
     tags-ignore:
       - '**'
     branches-ignore:


### PR DESCRIPTION
Update references to `readme.html` to use `manual_readme_content.md` instead. We should eventually convert to using the md files to avoid the extra translation from HTML to markdown since nothing uses the HTML anymore.