### PR TITLE
PAPP-35484: Build needs to be able access S3

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,11 +14,12 @@ jobs:
         uses: splunk-soar-connectors/.github/.github/actions/pre-commit@main
 
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
+      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
     needs: pre-commit
     steps:
-      - name: Setup Environment
-        uses: splunk-soar-connectors/.github/.github/actions/env-setup@main
+      - uses: actions/checkout@v4
 
       - name: Build Application
         uses: splunk-soar-connectors/.github/.github/actions/build-app@main


### PR DESCRIPTION
## What is the current behavior? (OPTIONAL)
- Build runs on a github runner which means it doesn't have access to s3. 
- Maxmind needs to pull files specified in build_config from s3, so build needs to access s3


## What is the new behavior? (OPTIONAL)
- Run the build app job on codebuild 
- The other solution is to use an AWS access key which should still let us run build on a github runner. But we'd then need to manage these secrets, which is why I think it makes more sense to take advantage of the already built out codebuild infra.  

passing build run: https://github.com/splunk-soar-connectors/maxmind/actions/runs/13554049905/job/37887609974?pr=29

---
Thanks for contributing!
