### PR TITLE
[maint] Fix ref bug

### DIFF
--- a/.github/actions/build-app/action.yml
+++ b/.github/actions/build-app/action.yml
@@ -9,5 +9,5 @@ runs:
 
     - name: Build App
       run: |
-        python ${{ github.action_path }}/build_app.py ${{ github.event.repository.name }} ${{ github.ref_name }} --output-dir=$(pwd)
+        python ${{ github.action_path }}/build_app.py ${{ github.event.repository.name }} ${{ github.head_ref }} --output-dir=$(pwd)
       shell: bash


### PR DESCRIPTION
Build had an issue where the branch would be like `32/merge` this is what the temp branch becomes during a PR. Bug can be seen here: https://github.com/splunk-soar-connectors/imap/actions/runs/13795343894/job/38588195655 (not sure if this happens every time because build was working before? But is fixed now nevertheless)

Changed to always get the correct branch from the PR.