### PR TITLE
PAPP-35630: Re-enable and optimize test coverage and package dependencies 

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -5,9 +5,6 @@ inputs:
     description: "Is the connector fips compliant"
     required: true
     default: "false"
-  publisher:
-    description: "Who is the connectors publisher"
-    required: true
   app_repo:
     description: "Connector repo being tested"
     required: true
@@ -46,12 +43,11 @@ runs:
           echo "Failed to authenticate with Vault!"
           exit 1
         fi
-        if [[ -d suite/apps/"${{ inputs.app_repo }}" ]]; then
-          pytest suite/apps/"${{ inputs.app_repo }}" --color=yes --reruns=$NUM_TEST_RETRIES
-        elif [[ "${{ inputs.publisher }}" == "Splunk" ]]; then
+        if [[ ! -d suite/apps/"${{ inputs.app_repo }}" ]]; then          
           echo "ERROR - expected to find test suite for Splunk supported app ${{ inputs.app_repo }}"
           exit 1
         fi
+        pytest suite/apps/"${{ inputs.app_repo }}" --color=yes --reruns=$NUM_TEST_RETRIES
     - name: Clean Up
       shell: bash
       if: always()

--- a/.github/actions/publish/upload_to_splunkbase.py
+++ b/.github/actions/publish/upload_to_splunkbase.py
@@ -132,13 +132,13 @@ def main(args):
         sb_appid = apps[0]["id"]
         logging.info("Found existing app with appid: %s: %s", appid, sb_appid)
         # package_id = sb_client.upload_app_version(
-        #     sb_appid, app_repo_name, tarball, release_notes, license_string, license_url
+        #    sb_appid, app_repo_name, tarball, release_notes, license_string, license_url
         # )
         package_id=-1
     else:
         logging.info("Could not find an app with appid: %s", appid)
         # package_id = sb_client.upload_app(
-        #     app_repo_name, tarball, release_notes, license_string, license_url
+        #    app_repo_name, tarball, release_notes, license_string, license_url
         # )
         package_id=-1
 

--- a/.github/actions/sanity-tests/action.yml
+++ b/.github/actions/sanity-tests/action.yml
@@ -5,9 +5,6 @@ inputs:
     description: "Is the connector fips compliant"
     required: true
     default: "false"
-  publisher:
-    description: "Who is the connectors publisher"
-    required: true
   phantom_ip:
     description: "Phantom instance the tests are ran on"
     required: true
@@ -56,9 +53,9 @@ runs:
           echo "Failed to authenticate with Vault!"
           exit 1
         fi
-        if [[ -d suite/apps/"${{ inputs.app_repo }}" ]]; then
-          pytest suite/apps/"${{ inputs.app_repo }}" -m "not ui" --color=yes --reruns=$NUM_TEST_RETRIES
-        elif [[ "${{ inputs.publisher }}" == "Splunk" ]]; then
+        if [[ ! -d suite/apps/"${{ inputs.app_repo }}" ]]; then
           echo "ERROR - expected to find test suite for Splunk supported app ${{ inputs.app_repo }}"
           exit 1
         fi
+        pytest suite/apps/"${{ inputs.app_repo }}" -m "not ui" --color=yes --reruns=$NUM_TEST_RETRIES
+

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,16 +21,6 @@ jobs:
       - name: Run Security Scans
         uses: splunk-soar-connectors/.github/.github/actions/security-scans@main
 
-  #test-coverage:
-  #  runs-on:
-  #    - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
-  #    - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
-  #  steps:
-  #    - uses: actions/checkout@v4
-
-  #    - name: Run Test Coverage
-  #      uses: splunk-soar-connectors/.github/.github/actions/test-coverage@main
-
   compile:
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
@@ -79,14 +69,28 @@ jobs:
       - name: Set outputs
         id: set-outputs
         run: |
+          echo ${{ env.publisher }}
           echo "publisher=${{ env.publisher }}" >> $GITHUB_OUTPUT
           echo "fips_compliant=${{ env.fips_compliant }}" >> $GITHUB_OUTPUT
+  
+  test-coverage:
+    runs-on:
+      - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
+      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
+    needs: test-setup
+    if: ${{ needs.test-setup.outputs.publisher == 'Splunk' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Test Coverage
+        uses: splunk-soar-connectors/.github/.github/actions/test-coverage@main
 
   sanity-test:
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
       - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
-    needs: [test-setup]
+    needs: test-setup
+    if: ${{ needs.test-setup.outputs.publisher == 'Splunk' }}
     strategy:
       fail-fast: false
       matrix:
@@ -97,8 +101,8 @@ jobs:
             ip: ${{ vars.PHANTOM_INSTANCE_NEXT_VERSION_IP }}
           - version: "previous"
             ip: ${{ vars.PHANTOM_INSTANCE_PREVIOUS_VERSION_IP }}
-          # - version: "cloud"
-          #   ip: ${{ vars.PHANTOM_INSTANCE_CLOUD_HOST }}
+          - version: "cloud"
+            ip: ${{ vars.PHANTOM_INSTANCE_CLOUD_HOST }}
           - version: "rhel"
             ip: ${{ vars.PHANTOM_INSTANCE_CURRENT_RHEL_VERSION_IP }}
     env:
@@ -120,7 +124,6 @@ jobs:
         uses: splunk-soar-connectors/.github/.github/actions/sanity-tests@main
         with:
           fips_compliant: ${{ needs.test-setup.outputs.fips_compliant }}
-          publisher: ${{ needs.test-setup.outputs.publisher }}
           phantom_ip: ${{ matrix.ip }}
           version: ${{ matrix.version }}
           app_repo: ${{ github.event.repository.name }}
@@ -129,7 +132,8 @@ jobs:
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
       - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
-    needs: [test-setup]
+    needs: test-setup
+    if: ${{ needs.test-setup.outputs.publisher == 'Splunk' }} 
     env:
       PHANTOM_INSTANCE_IP: ${{ vars.PHANTOM_INSTANCE_IP }}
       PHANTOM_INSTANCE_IP_FIPS: ${{ vars.PHANTOM_INSTANCE_IP_FIPS }}
@@ -149,5 +153,4 @@ jobs:
         uses: splunk-soar-connectors/.github/.github/actions/integration-tests@main
         with:
           fips_compliant: ${{ needs.test-setup.outputs.fips_compliant }}
-          publisher: ${{ needs.test-setup.outputs.publisher }}
           app_repo: ${{ github.event.repository.name }}


### PR DESCRIPTION
- Re-enable test_coverage, package dependencies and cloud tests
- Only run test_coverage, sanity tests and integration tests for splunk supported apps

Passing community app pipeline: https://github.com/splunk-soar-connectors/akamaiwaf/actions/runs/13996630858
Passing splunk supported pipeline: https://github.com/splunk-soar-connectors/ciscotalosintelligence/actions/runs/13996562117
