### PR TITLE
maint: fix to tests that require ab

### DIFF
--- a/.github/actions/sanity-tests/action.yml
+++ b/.github/actions/sanity-tests/action.yml
@@ -14,9 +14,6 @@ inputs:
   app_repo:
     description: "Connector repo being tested"
     required: true
-  automation_broker:
-    description: "Automation broker to use for cloud tests"
-    required: false
 runs:
   using: "composite"
   steps:
@@ -50,11 +47,7 @@ runs:
           git checkout main
         fi
         if [[ "${{ inputs.version }}" == "cloud" ]]; then
-          if [[ "${{ inputs.automation_broker }}" == "" ]]; then
-            echo "ERROR - automation_broker is required for cloud!"
-            exit 1
-          fi
-          export AUTOMATION_BROKER="${{ inputs.automation_broker }}"
+          export AUTOMATION_BROKER="$AUTOMATION_BROKER_NAME"
           echo "Tests will use automation broker $AUTOMATION_BROKER"
         fi
         if ! vault login -method=aws role=$VAULT_ROLE &> /dev/null; then

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -105,7 +105,6 @@ jobs:
             ip: ${{ vars.PHANTOM_INSTANCE_PREVIOUS_VERSION_IP }}
           - version: "cloud"
             ip: ${{ vars.PHANTOM_INSTANCE_CLOUD_HOST }}
-            automation_broker: ${{ vars.AUTOMATION_BROKER_NAME }}
           - version: "rhel"
             ip: ${{ vars.PHANTOM_INSTANCE_CURRENT_RHEL_VERSION_IP }}
     env:


### PR DESCRIPTION
- added the AUTOMATION_BROKER_NAME env variable to the codebuild job env instead of storing it in github
- cloud test that picked up broker: https://github.com/splunk-soar-connectors/ssh/actions/runs/14077009676/job/39421778972
- asset has broker now: https://ssc-cicd-sanity-tests.soar.stg.splunkcloud.com/apps/127/asset/22453/