### PR TITLE
fix: metrics job failing if old app json too large

### DIFF
--- a/.github/actions/metrics/action.yml
+++ b/.github/actions/metrics/action.yml
@@ -28,6 +28,8 @@ runs:
           echo "No JSON file found."
           exit 0
         fi
-
+        temp_old_json_file=$(mktemp)
         old_json=$(git show HEAD^:"$APP_JSON_NAME" 2>/dev/null || echo "{}")
-        python ${{ github.action_path }}/send_metrics.py "$APP_JSON" "$old_json" --publish-code ${{ inputs.publish_return_code }} -t 600
+        echo "$old_json" > "$temp_old_json_file"
+        python ${{ github.action_path }}/send_metrics.py "$APP_JSON" "$temp_old_json_file" --publish-code ${{ inputs.publish_return_code }} -t 600
+        rm -f "$temp_file"

--- a/.github/actions/metrics/send_metrics.py
+++ b/.github/actions/metrics/send_metrics.py
@@ -17,7 +17,7 @@ from utils.api.gitlab import GitLabApi
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("app_json_path", help="Path to the JSON file in the Git repository")
-    parser.add_argument("old_app_json", help="App json before the merge")
+    parser.add_argument("old_app_json_path", help="Path to file containing app json before the merge")
     parser.add_argument(
         "-t", "--timeout", type=int, default=1200, help="Max time in seconds to wait for completion"
     )
@@ -47,9 +47,9 @@ def _poll_pipeline_completion(
 def main(args):
     try:
         app_json = Path(args.app_json_path)
-        new_app_json = app_json.read_text()
-        new_json_data = json.loads(new_app_json)
-        old_json_data = json.loads(args.old_app_json)
+        new_json_data = json.loads(app_json.read_text())
+        old_app_json = Path(args.old_app_json_path)
+        old_json_data = json.loads(old_app_json.read_text())
     except FileNotFoundError:
         logging.error(f"File not found: {app_json}")
         return 1


### PR DESCRIPTION
### Features
<!-- Delete this section if your PR does not add any features -->
List any features you're adding to this app (e.g. new actions, parameters, auth methods, etc.)

-

### Bug Fixes
<!-- Delete this section if your PR does not fix any bugs -->
Describe any bugs you've fixed in this app, and how they were fixed
- The old app json was being passed as text which resulted in bash throwing argument list too longs for some connectors where the json's were too large
- This fix stores the old json in a temporary file and passes the path to the send_metrics script

test run: https://github.com/splunk-soar-connectors/frictionless_connectors_test/actions/runs/14743767539/job/41388005062

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [ ] I have verified that manual documentation has been updated where appropriate

### Other information
<!-- Delete this entire section if unused -->
<!-- Please add any other pertinent information you would like reviewers to know about your change -->

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
