### PR TITLE
fix: deal with special characters in publisher name properly

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -89,7 +89,7 @@ jobs:
         id: set-outputs
         run: |
           echo "${{ env.publisher }}"
-          echo "publisher='${{ env.publisher }}'" >> $GITHUB_OUTPUT
+          echo publisher="${{ env.publisher }}" >> $GITHUB_OUTPUT
           echo "fips_compliant=${{ env.fips_compliant }}" >> $GITHUB_OUTPUT
 
   test-coverage:


### PR DESCRIPTION
### Features
<!-- Delete this section if your PR does not add any features -->
List any features you're adding to this app (e.g. new actions, parameters, auth methods, etc.)

-

### Bug Fixes
<!-- Delete this section if your PR does not fix any bugs -->
Describe any bugs you've fixed in this app, and how they were fixed

- The previous change made to deal with special characters lead to the publisher having quotes around it in the env file, which meant that a check like this `${{ needs.test-setup.outputs.publisher == 'Splunk' }}` would fail, causing splunk supported apps to not run test-coverage, sanity-test or integration-tests

job run showing splunk supported app running all jobs: https://github.com/splunk-soar-connectors/frictionless_connectors_test/actions/runs/14756963850

job run showing special characters being handled properly: https://github.com/splunk-soar-connectors/frictionless_connectors_test/actions/runs/14757078541

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [ ] I have verified that manual documentation has been updated where appropriate

### Other information
<!-- Delete this entire section if unused -->
<!-- Please add any other pertinent information you would like reviewers to know about your change -->

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
