### PR TITLE
chore: disable publish workflow to merge in code without publishing updates to splunkbase

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   semantic-version:
+      if: false
       runs-on: ubuntu-latest
       permissions:
         contents: write
@@ -81,6 +82,7 @@ jobs:
               rm -f update_version.py
 
   build:
+    if: false
     runs-on: ubuntu-latest
     needs: semantic-version
     steps:
@@ -111,6 +113,7 @@ jobs:
           path: /tmp/${{ github.event.repository.name }}.tgz
 
   publish:
+    if: false
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
       - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
@@ -149,11 +152,12 @@ jobs:
 
 
   metrics:
+    if: false
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
       - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
     needs: publish
-    if: always()
+    # if: always()
     steps:
     - name: Check out app repo
       uses: actions/checkout@v4


### PR DESCRIPTION
### Features
<!-- Delete this section if your PR does not add any features -->
List any features you're adding to this app (e.g. new actions, parameters, auth methods, etc.)

- Disabling the publish workflow using if: false on each job.
- This is to merge in dependency updates which would cause releases when merged. We are freezing releases of apps until after the borg app cutoff.

### Bug Fixes
<!-- Delete this section if your PR does not fix any bugs -->
Describe any bugs you've fixed in this app, and how they were fixed

-

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [ ] I have verified that manual documentation has been updated where appropriate

### Other information
<!-- Delete this entire section if unused -->
<!-- Please add any other pertinent information you would like reviewers to know about your change -->

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
