### PR TITLE
fix: only run aggregate action when tests are ran

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -181,8 +181,8 @@ jobs:
 
   aggregate-sanity-results:
     runs-on: ubuntu-latest
-    needs: sanity-test
-    if: always()
+    needs: [sanity-test, test-setup]
+    if: always() && needs.test-setup.outputs.publisher == 'Splunk'
     steps:
       - name: Download All Sanity Test Artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
### Features
<!-- Delete this section if your PR does not add any features -->
List any features you're adding to this app (e.g. new actions, parameters, auth methods, etc.)

-

### Bug Fixes
<!-- Delete this section if your PR does not fix any bugs -->
Describe any bugs you've fixed in this app, and how they were fixed

- Run aggregate tests results action only when there are test results (i.e. on splunk supported apps). This prevents the job from failing for non-splunk supported apps because they have no sanity tests.

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [ ] I have verified that manual documentation has been updated where appropriate

### Other information
<!-- Delete this entire section if unused -->
<!-- Please add any other pertinent information you would like reviewers to know about your change -->

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
