### PR TITLE
fix: remove unused env var to fix backtick parsing

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,7 @@
         [
             "@semantic-release/exec",
             {
-                "prepareCmd": "rm -f package.json package-lock.json .releaserc.json && RELEASE_NOTES=\"${nextRelease.notes}\" python update_version.py ${nextRelease.version}"
+                "prepareCmd": "rm -f package.json package-lock.json .releaserc.json && python update_version.py ${nextRelease.version}"
             }
         ],
         [


### PR DESCRIPTION
remove unused RELEASE_NOTES env var to fix backtick parsing

Comment from update_version.py: **# Explored but currently not using: auto-generating release notes with ${nextRelease.notes} from semantic release**

Issue with the semantic-release workflow: https://github.com/splunk-soar-connectors/recordedfuture/actions/runs/21023739779/job/61761629116