### PR TITLE
fix: run subset of aws tests, as full suite is too long PAPP-37596

### DIFF
--- a/.github/actions/sanity-tests/action.yml
+++ b/.github/actions/sanity-tests/action.yml
@@ -72,7 +72,14 @@ runs:
         # Create results directory and run pytest with output capture
         mkdir -p "${{ github.workspace }}/test-results"
         echo "Running tests and capturing output to ${{ github.workspace }}/test-results/pytest-output-raw.log"
-        pytest suite/apps/"${{ inputs.app_repo }}" -m "not ui and sanity" --verbose --reruns=$NUM_TEST_RETRIES --tb=native --color=yes | tee "${{ github.workspace }}/test-results/pytest-output-raw.log"
+        # For AWS apps, use certification-style test filtering to exclude long-running playbook tests
+        # Keeps _000 tests (base sanity tests), excludes _001-_016 (playbook tests)
+        if [[ "${{ inputs.app_repo }}" == *"aws"* ]]; then
+          echo "AWS app detected - applying test name filtering to exclude playbook tests (_001 through _016)"
+          pytest suite/apps/"${{ inputs.app_repo }}" -m "not ui and sanity" -k "(test_connectivity or test_action) and not bad_asset and not (_001 or _002 or _003 or _004 or _005 or _006 or _007 or _008 or _009 or _010 or _011 or _012 or _013 or _014 or _015 or _016)" --verbose --reruns=$NUM_TEST_RETRIES --tb=native --color=yes | tee "${{ github.workspace }}/test-results/pytest-output-raw.log"
+        else
+          pytest suite/apps/"${{ inputs.app_repo }}" -m "not ui and sanity" --verbose --reruns=$NUM_TEST_RETRIES --tb=native --color=yes | tee "${{ github.workspace }}/test-results/pytest-output-raw.log"
+        fi
         # Capture the pytest exit code from the pipeline
         PYTEST_EXIT_CODE=${PIPESTATUS[0]}
         echo "Test output saved to ${{ github.workspace }}/test-results/pytest-output-raw.log (exit code: $PYTEST_EXIT_CODE)"


### PR DESCRIPTION
### Features
<!-- Delete this section if your PR does not add any features -->
List any features you're adding to this app (e.g. new actions, parameters, auth methods, etc.)

- aws test suites time out in the github CI, this will hopefully allow these tests to complete by reducing the amount of tests ran (while still covering all actions)

### Bug Fixes
<!-- Delete this section if your PR does not fix any bugs -->
Describe any bugs you've fixed in this app, and how they were fixed

-

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [ ] I have verified that manual documentation has been updated where appropriate

### Other information
<!-- Delete this entire section if unused -->
<!-- Please add any other pertinent information you would like reviewers to know about your change -->

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
