### PR TITLE
fix: allow aws instance connections as optional for sanity tests

### DIFF
--- a/.github/actions/sanity-tests/action.yml
+++ b/.github/actions/sanity-tests/action.yml
@@ -37,8 +37,16 @@ runs:
         export PHANTOM_URL="https://$phantom_ip"
         python ${{ github.action_path }}/../../utils/app_rest_installer.py ${{ inputs.app_repo }}.tgz $phantom_ip $PHANTOM_USERNAME $PHANTOM_PASSWORD
         if [[ "${{ inputs.app_repo }}" == *"aws"* ]]; then
-          python ${{ github.action_path }}/../../utils/app_rest_installer.py ${{ inputs.app_repo }}.tgz "$AWS_PHANTOM_INSTANCE_CURRENT_VERSION_IP" $AWS_PHANTOM_USERNAME $AWS_PHANTOM_PASSWORD
-          python ${{ github.action_path }}/../../utils/app_rest_installer.py ${{ inputs.app_repo }}.tgz "$AWS_PHANTOM_INSTANCE_PREVIOUS_VERSION_IP" $AWS_PHANTOM_USERNAME $AWS_PHANTOM_PASSWORD
+          if [[ -n "$AWS_PHANTOM_INSTANCE_CURRENT_VERSION_IP" ]]; then
+            python ${{ github.action_path }}/../../utils/app_rest_installer.py ${{ inputs.app_repo }}.tgz "$AWS_PHANTOM_INSTANCE_CURRENT_VERSION_IP" $AWS_PHANTOM_USERNAME $AWS_PHANTOM_PASSWORD
+          else
+            echo "AWS_PHANTOM_INSTANCE_CURRENT_VERSION_IP is not set, skipping install on AWS current instance."
+          fi
+          if [[ -n "$AWS_PHANTOM_INSTANCE_PREVIOUS_VERSION_IP" ]]; then
+            python ${{ github.action_path }}/../../utils/app_rest_installer.py ${{ inputs.app_repo }}.tgz "$AWS_PHANTOM_INSTANCE_PREVIOUS_VERSION_IP" $AWS_PHANTOM_USERNAME $AWS_PHANTOM_PASSWORD
+          else
+            echo "AWS_PHANTOM_INSTANCE_PREVIOUS_VERSION_IP is not set, skipping install on AWS previous instance."
+          fi
         fi
         cd ../app-tests
         if ! git checkout origin/$APP_TESTS_BRANCH &> /dev/null; then


### PR DESCRIPTION
### Features
<!-- Delete this section if your PR does not add any features -->
List any features you're adding to this app (e.g. new actions, parameters, auth methods, etc.)

-

### Bug Fixes
<!-- Delete this section if your PR does not fix any bugs -->
Describe any bugs you've fixed in this app, and how they were fixed

- AWS instances are currently broken and are preventing running cicd tests for aws apps 

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [ ] I have verified that manual documentation has been updated where appropriate

### Other information
<!-- Delete this entire section if unused -->
<!-- Please add any other pertinent information you would like reviewers to know about your change -->

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
