### PR TITLE
Replace Lambda Slack notifications with GitHub Actions notify-slack job

### DIFF
--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -1,0 +1,68 @@
+name: "Notify Slack on App Release"
+description: "Posts a release notification to the appropriate Slack channel"
+inputs:
+  app_name:
+    description: "Name of the published app"
+    required: true
+  app_logo:
+    description: "Path to the app logo SVG within the checked-out repo"
+    required: true
+  repo_name:
+    description: "GitHub repository name"
+    required: true
+  release_version:
+    description: "Published version"
+    required: true
+  release_notes:
+    description: "JSON-encoded list of release note lines"
+    required: true
+  new_app:
+    description: "Whether this is a new app ('true' or 'false')"
+    required: true
+  support_tag:
+    description: "Splunkbase support tag (splunk, developer, not_supported)"
+    required: true
+  splunk_base_url:
+    description: "URL to the app on Splunkbase"
+    required: true
+  slack_internal_token:
+    description: "Slack bot token for the internal channel"
+    required: true
+  slack_community_token:
+    description: "Slack bot token for the community channel"
+    required: true
+  slack_internal_channel:
+    description: "Internal Slack channel ID or name"
+    required: false
+    default: "soar-apps"
+  slack_community_channel:
+    description: "Community Slack channel ID or name"
+    required: false
+    default: "soar-app-changes"
+runs:
+  using: "composite"
+  steps:
+    - name: Install system dependencies
+      run: yum install -y cairo || apt-get install -y libcairo2 || true
+      shell: bash
+
+    - name: Install Python requirements
+      run: pip install -r ${{ github.action_path }}/requirements.txt
+      shell: bash
+
+    - name: Send Slack notification
+      env:
+        APP_NAME: ${{ inputs.app_name }}
+        APP_LOGO: ${{ inputs.app_logo }}
+        REPO_NAME: ${{ inputs.repo_name }}
+        RELEASE_VERSION: ${{ inputs.release_version }}
+        RELEASE_NOTES: ${{ inputs.release_notes }}
+        NEW_APP: ${{ inputs.new_app }}
+        SUPPORT_TAG: ${{ inputs.support_tag }}
+        SPLUNK_BASE_URL: ${{ inputs.splunk_base_url }}
+        SLACK_INTERNAL_TOKEN: ${{ inputs.slack_internal_token }}
+        SLACK_COMMUNITY_TOKEN: ${{ inputs.slack_community_token }}
+        SLACK_INTERNAL_CHANNEL: ${{ inputs.slack_internal_channel }}
+        SLACK_COMMUNITY_CHANNEL: ${{ inputs.slack_community_channel }}
+      run: python ${{ github.action_path }}/notify_slack.py
+      shell: bash

--- a/.github/actions/notify-slack/notify_slack.py
+++ b/.github/actions/notify-slack/notify_slack.py
@@ -1,0 +1,209 @@
+"""
+Sends a Slack notification for an app release or pending review.
+Adapted from lambdas/src/post_release/slack/notify_slack_channel.py for GitHub Actions.
+Channel routing (per support_tag) replaces the Lambda's per-channel deployment model.
+"""
+
+import json
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+
+# Nasty hack to make cairo work with pyenv on MacOs
+if os.path.exists("/opt/homebrew/lib"):
+    from ctypes.macholib import dyld
+
+    dyld.DEFAULT_LIBRARY_FALLBACK.append("/opt/homebrew/lib")
+
+import cairosvg
+import requests
+from jinja2 import Environment, FileSystemLoader
+from slack_sdk import WebClient
+
+TEMPLATES_DIR = Path(__file__).parent / "templates"
+RELEASE_TEMPLATE = "release_message.txt.j2"
+PENDING_REVIEW_TEMPLATE = "pending_review_message.txt.j2"
+
+SUPPORT_TAG_ALIASES = {
+    "splunk": "Splunk-supported",
+    "developer": "developer-supported",
+    "not_supported": "community-supported",
+}
+
+MD_INDENT_MIN_SPACES = 2
+INDENTS_TO_SLACK_LIST_SYMBOLS = {0: "●", 1: "⚬", 2: "■", 3: "●", 4: "⚬"}
+SLACK_LIST_ITEM_PADDING_LEFT = (
+    3  # Number of spaces to indent a list bullet from the beginning of a line
+)
+SLACK_LIST_ITEM_PADDING_RIGHT = 3  # Number of spaces between a list bullet and the content
+SLACK_INDENT_NUM_SPACES = 4
+SLACK_LIST_MAX_INDENTS = 5
+
+RELEASE_NOTE_PATTERN = re.compile(r"^\s*\*\s*(?P<note>.+)$")
+
+
+def _convert_release_notes_to_slack_list(release_notes):
+    """
+    The Slack API doesn't support list formatting so we'll have to explicitly
+    generate the list ahead of time
+    """
+    if not release_notes:
+        return []
+
+    converted_notes, parent_depths = [], [0]
+    for note in release_notes:
+        if not note:
+            continue
+        note_match = RELEASE_NOTE_PATTERN.match(note)
+        if not note_match:
+            logging.warning("Excluding release note in unexpected format: %s", note)
+            continue
+        curr_depth = note.index("*")
+        while True:
+            if not parent_depths:
+                parent_depths.append(curr_depth)
+                break
+            diff = curr_depth - parent_depths[-1]
+            if 0 <= diff < MD_INDENT_MIN_SPACES:
+                parent_depths[-1] = curr_depth
+                break
+            elif diff > MD_INDENT_MIN_SPACES:
+                parent_depths.append(curr_depth)
+                break
+            else:  # diff < 0
+                parent_depths.pop()
+
+        num_indents = min(len(parent_depths) - 1, SLACK_LIST_MAX_INDENTS)
+        list_item = (
+            [" "] * SLACK_LIST_ITEM_PADDING_LEFT
+            + [" "] * num_indents * SLACK_LIST_MAX_INDENTS
+            + [INDENTS_TO_SLACK_LIST_SYMBOLS[num_indents]]
+            + [" "] * SLACK_LIST_ITEM_PADDING_RIGHT
+            + list(note_match.group("note"))
+        )
+        converted_notes.append("".join(list_item))
+
+    return converted_notes
+
+
+def _build_message(
+    app_name,
+    support_tag,
+    splunk_base_url,
+    release_notes=None,
+    new_app=False,
+    template_name=RELEASE_TEMPLATE,
+):
+    support_alias = SUPPORT_TAG_ALIASES.get(support_tag)
+    if not support_alias:
+        err_msg = f"Unrecognized support tag {support_tag}"
+        logging.error(err_msg)
+        raise ValueError(err_msg)
+
+    jinja_env = Environment(loader=FileSystemLoader(str(TEMPLATES_DIR)))
+    template = jinja_env.get_template(template_name)
+    return template.render(
+        app_name=app_name,
+        support_alias=support_alias,
+        splunk_base_url=splunk_base_url,
+        release_notes=_convert_release_notes_to_slack_list(release_notes),
+        new_app=new_app,
+    )
+
+
+def _convert_svg_logo_to_png(repo_name, repo_svg_logo_path):
+    """
+    Reads the SVG logo from the local checkout (GITHUB_WORKSPACE) and converts to PNG bytes.
+    In the Lambda, this fetches from the GitHub API; here we have the repo checked out already.
+    """
+    workspace = os.getenv("GITHUB_WORKSPACE", ".")
+    svg_path = Path(workspace) / repo_svg_logo_path
+    logging.info("Reading SVG logo from %s (repo: %s)", svg_path, repo_name)
+    return cairosvg.svg2png(bytestring=svg_path.read_bytes())
+
+
+def _notify_slack_channel(slack_client, slack_channel, release_data):
+    if release_data["app_logo"].split(".")[-1] != "svg":
+        err_msg = f"Expected logo to be in SVG but got {release_data['app_logo']}"
+        logging.error(err_msg)
+        raise ValueError(err_msg)
+
+    template_name = PENDING_REVIEW_TEMPLATE if release_data["new_app"] else RELEASE_TEMPLATE
+    release_message = _build_message(
+        app_name=release_data["app_name"],
+        support_tag=release_data["support_tag"],
+        release_notes=release_data["release_notes"],
+        splunk_base_url=release_data["splunk_base_url"],
+        new_app=release_data["new_app"],
+        template_name=template_name,
+    )
+    png_bytes = _convert_svg_logo_to_png(
+        repo_name=release_data["repo_name"], repo_svg_logo_path=release_data["app_logo"]
+    )
+
+    logging.info("Uploading release message to %s", slack_channel)
+
+    # Step 1: Get upload URL from Slack
+    filename = f"{release_data['repo_name']}_logo.png"
+    file_size = len(png_bytes)
+
+    logging.info("Getting upload URL for file %s (size: %d bytes)", filename, file_size)
+    upload_url_response = slack_client.files_getUploadURLExternal(
+        filename=filename, length=file_size
+    )
+
+    if not upload_url_response.get("ok"):
+        raise RuntimeError(f"Failed to get upload URL: {upload_url_response.get('error')}")
+
+    upload_url = upload_url_response["upload_url"]
+    file_id = upload_url_response["file_id"]
+
+    # Step 2: Upload file to the provided URL
+    logging.info("Uploading file to Slack (file_id: %s)", file_id)
+    upload_response = requests.post(upload_url, data=png_bytes)
+    upload_response.raise_for_status()
+
+    # Step 3: Complete the upload with channel and message
+    logging.info("Completing upload to channel %s", slack_channel)
+    complete_response = slack_client.files_completeUploadExternal(
+        files=[{"id": file_id, "title": filename}],
+        channel_id=slack_channel,
+        initial_comment=release_message,
+    )
+
+    if not complete_response.get("ok"):
+        raise RuntimeError(f"Failed to complete upload: {complete_response.get('error')}")
+
+    logging.info("Successfully uploaded file to Slack")
+
+
+def main():
+    logging.getLogger().setLevel(logging.INFO)
+
+    release_data = {
+        "app_name": os.environ["APP_NAME"],
+        "app_logo": os.environ["APP_LOGO"],
+        "repo_name": os.environ["REPO_NAME"],
+        "release_version": os.environ["RELEASE_VERSION"],
+        "release_notes": json.loads(os.environ["RELEASE_NOTES"]),
+        "new_app": os.environ["NEW_APP"].lower() == "true",
+        "support_tag": os.environ["SUPPORT_TAG"],
+        "splunk_base_url": os.environ["SPLUNK_BASE_URL"],
+    }
+
+    # Route: splunk-supported → internal channel, everything else → community channel
+    if release_data["support_tag"] == "splunk":
+        slack_bot_token = os.environ["SLACK_INTERNAL_TOKEN"]
+        slack_channel = os.environ["SLACK_INTERNAL_CHANNEL"]
+    else:
+        slack_bot_token = os.environ["SLACK_COMMUNITY_TOKEN"]
+        slack_channel = os.environ["SLACK_COMMUNITY_CHANNEL"]
+
+    slack_client = WebClient(token=slack_bot_token)
+    _notify_slack_channel(slack_client, slack_channel, release_data)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/actions/notify-slack/requirements.txt
+++ b/.github/actions/notify-slack/requirements.txt
@@ -1,0 +1,4 @@
+CairoSVG==2.7.0
+Jinja2==3.1.5
+requests==2.32.2
+slack-sdk==3.41.0

--- a/.github/actions/notify-slack/templates/pending_review_message.txt.j2
+++ b/.github/actions/notify-slack/templates/pending_review_message.txt.j2
@@ -1,0 +1,7 @@
+*Hello* :wave:
+
+A new *{{ support_alias }}* app has been submitted to Splunkbase and is pending review! :hourglass_flowing_sand:
+
+:splunk-arrow: *{{ app_name }}* v{{ release_version }}
+
+The app will be available at <{{ splunk_base_url }}|Splunkbase> once it has been approved by the Splunkbase team.

--- a/.github/actions/notify-slack/templates/release_message.txt.j2
+++ b/.github/actions/notify-slack/templates/release_message.txt.j2
@@ -1,0 +1,9 @@
+*Hello* :wave:
+
+{% if new_app %}A new{% else %}An updated{% endif %} *{{ support_alias }}* app is now available on Splunkbase! :release:
+
+:splunk-arrow: <{{ splunk_base_url }}|*{{ app_name }}*>
+
+{%- for note in release_notes %}
+{{ note }}
+{%- endfor %}

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -4,6 +4,31 @@ inputs:
   is_sdkfied:
     description: 'Whether this is an SDKfied app (true/false)'
     required: true
+outputs:
+  app_name:
+    description: "Name of the published app"
+    value: ${{ steps.publish_app.outputs.app_name }}
+  app_logo:
+    description: "Path to the app logo SVG within the repo"
+    value: ${{ steps.publish_app.outputs.app_logo }}
+  repo_name:
+    description: "GitHub repository name"
+    value: ${{ steps.publish_app.outputs.repo_name }}
+  release_version:
+    description: "Published version"
+    value: ${{ steps.publish_app.outputs.release_version }}
+  release_notes:
+    description: "JSON-encoded list of release note lines"
+    value: ${{ steps.publish_app.outputs.release_notes }}
+  new_app:
+    description: "Whether this is a new app (true/false)"
+    value: ${{ steps.publish_app.outputs.new_app }}
+  support_tag:
+    description: "Splunkbase support tag (splunk, developer, not_supported)"
+    value: ${{ steps.publish_app.outputs.support_tag }}
+  splunk_base_url:
+    description: "URL to the app on Splunkbase"
+    value: ${{ steps.publish_app.outputs.splunk_base_url }}
 runs:
   using: "composite"
   steps:

--- a/.github/actions/publish/upload_to_splunkbase.py
+++ b/.github/actions/publish/upload_to_splunkbase.py
@@ -12,8 +12,6 @@ import tarfile
 from packaging.version import parse
 from typing import Any, Optional, Union
 
-import boto3
-
 # Add utils to the import path
 REPO_ROOT = Path(__file__).parent.parent.parent.resolve()
 sys.path.append(str(REPO_ROOT))
@@ -32,11 +30,8 @@ NEW_APP_WARNING_MESSAGE = (
     "See: http://go/new-soar-app-in-splunkbase for more."
 )
 
-RELEASE_QUEUE_URL = os.getenv("RELEASE_QUEUE_URL")
-SOAR_APPS_TOKEN = os.getenv("SOAR_APPS_TOKEN")
 SPLUNKBASE_USER = os.getenv("SPLUNKBASE_USER")
 SPLUNKBASE_PASSWORD = os.getenv("SPLUNKBASE_PASSWORD")
-RELEASE_QUEUE_REGION = "us-west-2"
 
 
 def parse_args() -> argparse.Namespace:
@@ -47,10 +42,9 @@ def parse_args() -> argparse.Namespace:
 
 
 def get_release_notes(version: str, workspace_path: Optional[Path] = None) -> Optional[str]:
-    
     # Use GITHUB_WORKSPACE if provided, otherwise fallback to cwd
     search_root = workspace_path or Path.cwd()
-    
+
     # Debug: Show where we're searching
     logging.info(f"Searching for release_notes from: {search_root}")
     if search_root.exists():
@@ -58,24 +52,28 @@ def get_release_notes(version: str, workspace_path: Optional[Path] = None) -> Op
     else:
         logging.error(f"Search root does not exist: {search_root}")
         return None
-    
+
     release_notes_file = search_root / "release_notes" / f"{version}.md"
     logging.info(f"Looking for release notes at: {release_notes_file}")
-    
-    with open(release_notes_file, "r") as f:
+
+    with open(release_notes_file) as f:
         full_release_notes = f.read()
         release_notes = []
         for line in full_release_notes.splitlines():
             if not ("unreleased" in line.lower() and "**" in line):
                 release_notes.append(line)
         return "\n".join(release_notes)
-   
+
 
 def get_app_json(tarball: Union[str, Path]) -> dict[str, Any]:
     with tarfile.open(tarball, "r") as tar:
         names = tar.getnames()
-        
-        app_json_files = [n for n in names if n.endswith(".json") and n.count("/") == 1 and "postman_collection" not in n.lower()]
+
+        app_json_files = [
+            n
+            for n in names
+            if n.endswith(".json") and n.count("/") == 1 and "postman_collection" not in n.lower()
+        ]
         if len(app_json_files) == 0 or len(app_json_files) > 1:
             raise ValueError(
                 f"No or multiple JSON files found in top level of app repo: {app_json_files}."
@@ -92,23 +90,33 @@ def get_license_info(app_json: dict[str, Any]) -> tuple[str, str]:
     return (APACHE2_LICENSE_STRING, APACHE2_LICENSE_URL)
 
 
-def _send_release_message(
-    repo_name: str, new_app: bool, release_notes: str, app_json: dict[str, Any]
+def _write_github_outputs(
+    app_json: dict[str, Any],
+    repo_name: str,
+    release_notes: str,
+    new_app: bool,
+    sb_appid: str,
+    support_tag: str,
 ) -> None:
-    sqs = boto3.resource("sqs", region_name=RELEASE_QUEUE_REGION)
-    queue = sqs.Queue(RELEASE_QUEUE_URL)
+    github_output = os.getenv("GITHUB_OUTPUT")
+    if not github_output:
+        logging.info("GITHUB_OUTPUT not set, skipping output writing")
+        return
 
-    message = {
-        "app_id": app_json["appid"],
-        "app_name": app_json["name"],
-        "app_logo": app_json["logo"],
-        "repo_name": repo_name,
-        "release_notes": release_notes.split("\n"),
-        "release_version": app_json["app_version"],
-        "new_app": new_app,
-    }
+    splunk_base_url = f"https://splunkbase.splunk.com/app/{sb_appid}"
+    release_notes_json = json.dumps(release_notes.split("\n"))
 
-    queue.send_message(MessageBody=json.dumps(message))
+    with open(github_output, "a") as f:
+        f.write(f"app_name={app_json['name']}\n")
+        f.write(f"app_logo={app_json['logo']}\n")
+        f.write(f"repo_name={repo_name}\n")
+        f.write(f"release_version={app_json['app_version']}\n")
+        f.write(f"new_app={'true' if new_app else 'false'}\n")
+        f.write(f"support_tag={support_tag}\n")
+        f.write(f"splunk_base_url={splunk_base_url}\n")
+        f.write(f"release_notes={release_notes_json}\n")
+
+    logging.info("Wrote GitHub outputs for %s v%s", app_json["name"], app_json["app_version"])
 
 
 def main(args):
@@ -142,7 +150,7 @@ def main(args):
     workspace = os.getenv("GITHUB_WORKSPACE")
     workspace_path = Path(workspace) if workspace else None
     logging.info(f"GITHUB_WORKSPACE from environment: {workspace}")
-    
+
     release_notes = get_release_notes(app_version, workspace_path)
     if not release_notes:
         logging.error("Could not find release notes in tarball for version %s!", app_version)
@@ -175,27 +183,28 @@ def main(args):
         logging.info("Failed to validate upload: \n%s", json.dumps(response, indent=2))
         return 1
 
-    # TODO: Change to get this to work correctly
-    # send_release_message = os.getenv("SEND_RELEASE_MESSAGE", "false").lower() in ("1", "true")
-    # if send_release_message:
-    #     logging.info(
-    #         f"sending a release message with repo_name={app_repo_name}, new_app={not apps}, release_notes={release_notes}"
-    #     )
-    #     _send_release_message(
-    #         repo_name=app_repo_name, new_app=not apps, app_json=app_json, release_notes=release_notes
-    #     )
-    # else:
-    #     logging.info("SEND_RELEASE_MESSAGE is not set to true; skipping release message.")
-
-    _send_release_message(
-        repo_name=app_repo_name, new_app=not apps, app_json=app_json, release_notes=release_notes
-    )
-
     if not apps:
+        support_tag = "splunk" if app_json.get("publisher") == "Splunk" else "developer"
+        _write_github_outputs(
+            app_json,
+            app_repo_name,
+            release_notes,
+            new_app=True,
+            sb_appid=sb_appid,
+            support_tag=support_tag,
+        )
         sb_client.add_app_editor(sb_appid)
         logging.warning(NEW_APP_WARNING_MESSAGE)
         return 2
 
+    _write_github_outputs(
+        app_json,
+        app_repo_name,
+        release_notes,
+        new_app=False,
+        sb_appid=sb_appid,
+        support_tag=apps[0]["support"],
+    )
     return 0
 
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,13 +3,15 @@ name: Reusable Publish Workflow
 on:
   workflow_call:
     secrets:
-      release_queue_url:
-        required: true
       splunkbase_user:
         required: true
       splunkbase_password:
         required: true
       semantic_release_pk:
+        required: true
+      slack_internal_token:
+        required: true
+      slack_community_token:
         required: true
 
 jobs:
@@ -97,10 +99,10 @@ jobs:
         id: detect
         run: |
           echo "Detecting app type..."
-          
+
           # Find uv.lock file and get its parent directory
           UV_LOCK_PATH=$(find . -name "uv.lock" -type f | head -1)
-          
+
           if [ -n "$UV_LOCK_PATH" ]; then
             UV_LOCK_DIR=$(dirname "$UV_LOCK_PATH")
             echo "Found uv.lock in directory: $UV_LOCK_DIR"
@@ -113,10 +115,10 @@ jobs:
             echo "is_sdkfied=false" >> $GITHUB_OUTPUT
             echo "uv_lock_directory=" >> $GITHUB_OUTPUT
           fi
-          
+
           echo "App detection completed"
         shell: bash
-  
+
   build:
     runs-on: ubuntu-latest
     needs: [semantic-version, detect-app-type]
@@ -145,13 +147,13 @@ jobs:
       - name: Build Application
         if: env.IS_SDKFIED == 'false'
         uses: splunk-soar-connectors/.github/.github/actions/build-app@main
-      
+
       - name: Setup SDKfied App Environment
         if: env.IS_SDKFIED == 'true'
         uses: splunk-soar-connectors/.github/.github/actions/sdkfied-app-setup@main
         with:
           uv_lock_directory: ${{ env.UV_LOCK_DIRECTORY }}
-      
+
       - name: Build SDK app
         if: env.IS_SDKFIED == 'true'
         run: |
@@ -174,6 +176,14 @@ jobs:
     needs: build
     outputs:
       return_code: ${{ steps.set-outputs.outputs.return_code }}
+      app_name: ${{ steps.publish_action.outputs.app_name }}
+      app_logo: ${{ steps.publish_action.outputs.app_logo }}
+      repo_name: ${{ steps.publish_action.outputs.repo_name }}
+      release_version: ${{ steps.publish_action.outputs.release_version }}
+      release_notes: ${{ steps.publish_action.outputs.release_notes }}
+      new_app: ${{ steps.publish_action.outputs.new_app }}
+      support_tag: ${{ steps.publish_action.outputs.support_tag }}
+      splunk_base_url: ${{ steps.publish_action.outputs.splunk_base_url }}
     permissions:
       contents: write
     steps:
@@ -190,10 +200,10 @@ jobs:
           path: ${{ github.workspace }}/artifacts
 
       - name: Publish
+        id: publish_action
         uses: splunk-soar-connectors/.github/.github/actions/publish@main
         env:
           UPLOAD_PATH: "${{ github.workspace }}/artifacts/${{ github.event.repository.name }}.tgz"
-          RELEASE_QUEUE_URL: ${{ secrets.release_queue_url }}
           SPLUNKBASE_USER: ${{ secrets.splunkbase_user }}
           SPLUNKBASE_PASSWORD: ${{ secrets.splunkbase_password }}
 
@@ -206,7 +216,7 @@ jobs:
             echo "Publish script failed with return code $return_code, failing the job."
             exit $return_code
           fi
-    
+
   metrics:
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
@@ -229,3 +239,32 @@ jobs:
       uses: splunk-soar-connectors/.github/.github/actions/metrics@main
       with:
         publish_return_code: ${{ needs.publish.outputs.return_code }}
+
+  notify-slack:
+    runs-on:
+      - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
+      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
+    needs: publish
+    if: always() && (needs.publish.outputs.return_code == '0' || needs.publish.outputs.return_code == '2')
+    steps:
+      - name: Check out app repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Notify Slack
+        uses: splunk-soar-connectors/.github/.github/actions/notify-slack@main
+        with:
+          app_name: ${{ needs.publish.outputs.app_name }}
+          app_logo: ${{ needs.publish.outputs.app_logo }}
+          repo_name: ${{ needs.publish.outputs.repo_name }}
+          release_version: ${{ needs.publish.outputs.release_version }}
+          release_notes: ${{ needs.publish.outputs.release_notes }}
+          new_app: ${{ needs.publish.outputs.new_app }}
+          support_tag: ${{ needs.publish.outputs.support_tag }}
+          splunk_base_url: ${{ needs.publish.outputs.splunk_base_url }}
+          slack_internal_token: ${{ secrets.slack_internal_token }}
+          slack_community_token: ${{ secrets.slack_community_token }}
+          slack_internal_channel: ${{ inputs.slack_internal_channel }}
+          slack_community_channel: ${{ inputs.slack_community_channel }}


### PR DESCRIPTION
## Summary
- Replaces the broken SQS → validate_release Lambda → SNS → notify_slack_channel Lambda pipeline with a new `notify-slack` composite action that runs directly in the publish workflow
- `upload_to_splunkbase.py`: removed boto3/SQS dependency, now writes app metadata (name, version, support_tag, splunk_base_url, etc.) to `$GITHUB_OUTPUT`
- New `notify-slack/` action adapted from the Lambda's `notify_slack_channel.py` — same message format, same 3-step Slack upload API, same release notes conversion
- Routes splunk-supported apps → internal channel (`soar-apps`), developer/community apps → community channel (`soar-app-changes`)
- New `pending_review_message.txt.j2` template for first-time app submissions (pending Splunkbase review)
- Includes `send_test_message.py` for local integration testing (tested successfully against both channels)

## Post-merge setup
- [ ] Update calling workflows that pass `release_queue_url` — that secret is no longer declared
- [ ] Once confirmed working, retire the Lambda infrastructure (SQS, SNS, validate_release, notify_slack_channel)

## Test plan
- [x] Tested release message locally via `send_test_message.py` → posted successfully to internal channel
- [x] Tested pending review message locally → posted successfully to internal channel
- [x] Tested community channel posting → posted successfully
- [ ] End-to-end test: trigger publish workflow on a test app repo after org secrets are configured