### PR TITLE
chore: allow disabling notify-slack job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -245,7 +245,7 @@ jobs:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
       - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
     needs: publish
-    if: always() && (needs.publish.outputs.return_code == '0' || needs.publish.outputs.return_code == '2')
+    if: always() && vars.SEND_RELEASE_MESSAGE == 'true' && (needs.publish.outputs.return_code == '0' || needs.publish.outputs.return_code == '2')
     steps:
       - name: Check out app repo
         uses: actions/checkout@v4


### PR DESCRIPTION
use `SEND_RELEASE_MESSAGE` variable to toggle slack message action