### PR TITLE
Fix PAPP Jira linking for external contributor PRs

### DIFF
--- a/.github/actions/pr-labeling/action.yml
+++ b/.github/actions/pr-labeling/action.yml
@@ -11,6 +11,12 @@ inputs:
   jira-api-key:
     description: 'Jira API key'
     required: false
+  splunkbase-user:
+    description: 'Splunkbase username (used to look up support status for existing apps)'
+    required: false
+  splunkbase-password:
+    description: 'Splunkbase password (used to look up support status for existing apps)'
+    required: false
   repo-name:
     description: 'Repository name'
     required: true
@@ -24,7 +30,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        pip install requests PyGithub gitpython
+        pip install requests PyGithub gitpython backoff
     
     - name: Run PR labeling
       shell: bash
@@ -32,6 +38,8 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         JIRA_USER: ${{ inputs.jira-user }}
         JIRA_API_KEY: ${{ inputs.jira-api-key }}
+        SPLUNKBASE_USER: ${{ inputs.splunkbase-user }}
+        SPLUNKBASE_PASSWORD: ${{ inputs.splunkbase-password }}
         REPO_NAME: ${{ inputs.repo-name }}
         PR_NUMBER: ${{ inputs.pr-number }}
       run: |

--- a/.github/actions/pr-labeling/assign_pr_labels.py
+++ b/.github/actions/pr-labeling/assign_pr_labels.py
@@ -24,11 +24,18 @@ EXTERNAL_CONTRIBUTOR_LABEL = "external-contributor"
 CERTIFIED_LABEL = "splunk-supported"
 NOT_CERTIFIED_LABEL = "developer-supported"
 
+# An app is "Splunk supported" only when its manifest declares this publisher.
+CERTIFIED_PUBLISHER = "Splunk"
+# Authored entry point for SDK-based apps (the manifest is generated at build
+# time, so publisher/appid/name live in the ``App(...)`` call in this file).
+SDK_APP_ENTRY = "src/app.py"
+
 # JIRA Configuration
 JIRA_URL = "https://splunk.atlassian.net"
 JIRA_PROJECT_KEY = "PAPP"
 JIRA_LABEL_PATTERN = re.compile(rf"^{JIRA_PROJECT_KEY}-[0-9]+$")
 JIRA_SUMMARY_TEMPLATE = "{} - {} App Open Source Submission"
+NEW_APP_SUMMARY_PREFIX = "[New App] "
 JIRA_DESCRIPTION_TEMPLATE = "Link to PR: {}\n\n{}"
 JIRA_ISSUE_TYPE = "Epic"
 JIRA_FIELD_EPIC_NAME = "customfield_11501"
@@ -39,7 +46,32 @@ JIRA_FIELD_COLOR_CERTIFIED_ID = "27194"
 JIRA_FIELD_COLOR_UNCERTIFIED_ID = "27195"
 
 
-def create_jira_ticket(jira_user, jira_api_key, app_name, is_certified, pr_info):
+def get_jira_account_id(auth):
+    """Return the accountId of the authenticated Jira user, or None.
+
+    Needed because ``reporter`` is a required field on the PAPP create screen.
+    """
+    try:
+        response = requests.get(
+            f"{JIRA_URL}/rest/api/2/myself",
+            headers={"Accept": "application/json"},
+            auth=auth,
+            timeout=30,
+        )
+        if response.status_code >= 400:
+            logging.error(
+                "Could not resolve Jira accountId (HTTP %s): %s",
+                response.status_code,
+                response.text,
+            )
+            return None
+        return response.json().get("accountId")
+    except requests.exceptions.RequestException as ex:
+        logging.exception("Failed to resolve Jira accountId: %s", ex)
+        return None
+
+
+def create_jira_ticket(jira_user, jira_api_key, app_name, is_certified, pr_info, is_new_app=False):
     """Create a JIRA ticket for external contributor PRs"""
     if not jira_user or not jira_api_key:
         logging.warning("JIRA credentials not provided, skipping ticket creation")
@@ -48,6 +80,8 @@ def create_jira_ticket(jira_user, jira_api_key, app_name, is_certified, pr_info)
     ticket_summary = JIRA_SUMMARY_TEMPLATE.format(
         app_name, CERTIFIED_LABEL.capitalize() if is_certified else NOT_CERTIFIED_LABEL.capitalize()
     )
+    if is_new_app:
+        ticket_summary = f"{NEW_APP_SUMMARY_PREFIX}{ticket_summary}"
 
     logging.info("Creating Jira ticket for %s", pr_info.html_url)
     
@@ -61,34 +95,52 @@ def create_jira_ticket(jira_user, jira_api_key, app_name, is_certified, pr_info)
     labels = [f"appname-{app_name}", EXTERNAL_CONTRIBUTOR_LABEL]
     if not is_certified:
         labels.append(NOT_CERTIFIED_LABEL)
-    
-    payload = {
-        "fields": {
-            "project": {"key": JIRA_PROJECT_KEY},
-            "summary": ticket_summary,
-            "description": JIRA_DESCRIPTION_TEMPLATE.format(pr_info.html_url, pr_info.body or ""),
-            "issuetype": {"name": JIRA_ISSUE_TYPE},
-            JIRA_FIELD_EPIC_NAME: ticket_summary,
-            JIRA_FIELD_PLATFORM: {"id": JIRA_FIELD_PLATFORM_PHANTOM_ID},
-            JIRA_FIELD_COLOR: {
-                "id": JIRA_FIELD_COLOR_CERTIFIED_ID
-                if is_certified
-                else JIRA_FIELD_COLOR_UNCERTIFIED_ID
-            },
-            "labels": labels,
-        }
+
+    fields = {
+        "project": {"key": JIRA_PROJECT_KEY},
+        "summary": ticket_summary,
+        "description": JIRA_DESCRIPTION_TEMPLATE.format(pr_info.html_url, pr_info.body or ""),
+        "issuetype": {"name": JIRA_ISSUE_TYPE},
+        JIRA_FIELD_EPIC_NAME: ticket_summary,
+        JIRA_FIELD_PLATFORM: {"id": JIRA_FIELD_PLATFORM_PHANTOM_ID},
+        JIRA_FIELD_COLOR: {
+            "id": JIRA_FIELD_COLOR_CERTIFIED_ID
+            if is_certified
+            else JIRA_FIELD_COLOR_UNCERTIFIED_ID
+        },
+        "labels": labels,
     }
-    
+
+    # `reporter` is required on the PAPP create screen. Interactive users get it
+    # auto-populated, but the CI service account does not, so the create fails
+    # with a 400. Set it explicitly to the authenticated account.
+    reporter_account_id = get_jira_account_id(auth)
+    if reporter_account_id:
+        fields["reporter"] = {"accountId": reporter_account_id}
+    else:
+        logging.warning(
+            "Proceeding without an explicit reporter; the create may fail if "
+            "the account cannot default the required reporter field."
+        )
+
     try:
         response = requests.post(
             f"{JIRA_URL}/rest/api/2/issue",
             headers=headers,
-            json=payload,
+            json={"fields": fields},
             auth=auth,
-            timeout=30
+            timeout=30,
         )
-        response.raise_for_status()
-        
+        if response.status_code >= 400:
+            # Surface the actual field-level validation error so failures are
+            # debuggable instead of a bare "400 Bad Request".
+            logging.error(
+                "Jira rejected ticket creation (HTTP %s): %s",
+                response.status_code,
+                response.text,
+            )
+            return None
+
         result = response.json()
         logging.info("Response from Jira: %s", result)
         return result["key"]
@@ -139,33 +191,153 @@ def find_app_json_name(json_filenames):
     return filtered_json_filenames[0]
 
 
-def get_app_json_from_repo(github_client, repo_name, pr_number):
-    """Attempt to read the app JSON from the app's repository"""
-    repo = github_client.get_repo(repo_name)
-    
-    # First try the default branch
+def _read_traditional_manifest_at_ref(repo, ref):
+    """Read the top-level JSON manifest for a traditional app, or None.
+
+    Traditional apps commit a single top-level ``*.json`` manifest carrying
+    ``publisher``/``appid``/``name``.
+    """
     try:
-        default_branch = repo.default_branch
-        contents = repo.get_contents("", ref=default_branch)
-        json_files = [item.name for item in contents if item.name.endswith(".json")]
-        app_json_name = find_app_json_name(json_files)
-        
-        app_json_contents = repo.get_contents(app_json_name, ref=default_branch)
-        return json.loads(app_json_contents.decoded_content.decode('utf-8'))
+        contents = repo.get_contents("", ref=ref)
     except Exception:
-        logging.info("Could not find app JSON in default branch of %s", repo_name)
-    
+        return None
+    json_files = [item.name for item in contents if item.name.endswith(".json")]
+    try:
+        app_json_name = find_app_json_name(json_files)
+    except ValueError:
+        return None
+    try:
+        raw = repo.get_contents(app_json_name, ref=ref).decoded_content.decode("utf-8")
+        manifest = json.loads(raw)
+    except Exception:
+        return None
+    return {
+        "publisher": manifest.get("publisher"),
+        "appid": manifest.get("appid"),
+        "name": manifest.get("name"),
+        "format": "traditional",
+    }
+
+
+def _grab_app_kwarg(block, key):
+    """Pull a string keyword value from the ``App(...)`` constructor block."""
+    match = re.search(rf"""{key}\s*=\s*["']([^"']*)["']""", block)
+    return match.group(1) if match else None
+
+
+def _read_sdk_manifest_at_ref(repo, ref):
+    """Read SDK app metadata from ``src/app.py``'s ``App(...)`` call, or None.
+
+    SDK apps do not commit a manifest; ``publisher``/``appid``/``name`` are
+    declared as keyword arguments to ``App(...)`` in the authored entry point.
+    """
+    try:
+        raw = repo.get_contents(SDK_APP_ENTRY, ref=ref).decoded_content.decode("utf-8")
+    except Exception:
+        return None
+    # Isolate the App(...) call so unrelated name= kwargs (e.g. on action
+    # decorators) are not picked up. The constructor has no nested parens.
+    call = re.search(r"App\((.*?)\)", raw, re.DOTALL)
+    block = call.group(1) if call else raw
+    return {
+        "publisher": _grab_app_kwarg(block, "publisher"),
+        "appid": _grab_app_kwarg(block, "appid"),
+        "name": _grab_app_kwarg(block, "name"),
+        "format": "sdk",
+    }
+
+
+def get_app_metadata_at_ref(repo, ref):
+    """Return ``{publisher, appid, name, format}`` for the app at ``ref``, or None.
+
+    Format-agnostic: tries the traditional JSON manifest first, then the SDK
+    ``src/app.py`` entry point. Returns None when neither marker exists, which
+    means the ref does not contain an app (e.g. a docs-only PR).
+    """
+    return _read_traditional_manifest_at_ref(repo, ref) or _read_sdk_manifest_at_ref(repo, ref)
+
+
+def get_app_context(github_client, repo_name, pr_number):
+    """Resolve app metadata and whether the PR introduces a brand-new app.
+
+    Returns ``(metadata, is_new_app)``. ``is_new_app`` is True when no app
+    exists on the default branch but one is present in the PR head. For
+    existing apps the default-branch metadata is authoritative (so the PR
+    cannot flip support status by editing the publisher field).
+    """
+    repo = github_client.get_repo(repo_name)
+
+    base_meta = get_app_metadata_at_ref(repo, repo.default_branch)
+    if base_meta is not None:
+        return base_meta, False
+
+    # Nothing on the default branch -> a PR that adds an app is a new app.
     try:
         pr = repo.get_pull(pr_number)
-        contents = repo.get_contents("", ref=pr.head.sha)
-        json_files = [item.name for item in contents if item.name.endswith(".json")]
-        app_json_name = find_app_json_name(json_files)
-        
-        app_json_contents = repo.get_contents(app_json_name, ref=pr.head.sha)
-        return json.loads(app_json_contents.decoded_content.decode('utf-8'))
+        head_meta = get_app_metadata_at_ref(repo, pr.head.sha)
     except Exception:
-        logging.info("Could not find app JSON in PR head branch for %s", repo_name)
+        logging.info("Could not read app metadata from PR head for %s", repo_name)
+        head_meta = None
+    return head_meta, head_meta is not None
+
+
+def splunkbase_is_supported(appid):
+    """Return True/False if Splunkbase marks the app Splunk-supported, else None.
+
+    Used for existing apps per the agreed model. Returns None (undecided) when
+    Splunkbase credentials or the helper are unavailable, or the app/field is
+    missing, so callers can fall back gracefully.
+    """
+    user = os.getenv("SPLUNKBASE_USER")
+    password = os.getenv("SPLUNKBASE_PASSWORD")
+    if not (user and password and appid):
+        logging.warning(
+            "Splunkbase support lookup skipped (missing credentials or appid); "
+            "support status left undecided."
+        )
         return None
+
+    try:
+        # Reuse the shared CI helper. Imported lazily so a missing dependency
+        # (e.g. backoff) degrades gracefully instead of failing the action.
+        utils_api = os.path.join(
+            os.path.dirname(__file__), "..", "..", "utils", "api"
+        )
+        if utils_api not in sys.path:
+            sys.path.insert(0, utils_api)
+        from splunkbase import Splunkbase  # type: ignore
+
+        results = Splunkbase(user, password).get_apps(extra_params={"appid": appid})
+    except Exception as ex:
+        logging.warning("Splunkbase support lookup failed: %s", ex)
+        return None
+
+    if not results:
+        logging.info("No Splunkbase entry for appid %s", appid)
+        return None
+    support = (results[0].get("support") or "").lower()
+    logging.info("Splunkbase support level for %s: %r", appid, support)
+    return "splunk" in support
+
+
+def determine_is_certified(metadata, is_new_app):
+    """Apply the agreed support model and return the certification flag.
+
+    New app  -> publisher field decides (Splunk => supported).
+    Existing -> Splunkbase ``support`` field decides; falls back to the
+                publisher field only when Splunkbase is undecided.
+    """
+    publisher = (metadata or {}).get("publisher")
+    publisher_supported = publisher == CERTIFIED_PUBLISHER
+
+    if is_new_app:
+        return publisher_supported
+
+    sb_supported = splunkbase_is_supported((metadata or {}).get("appid"))
+    if sb_supported is None:
+        logging.info("Falling back to publisher field for support decision.")
+        return publisher_supported
+    return sb_supported
 
 
 def post_acknowledging_comment(github_client, repo_name, pr_number):
@@ -221,30 +393,44 @@ def assign_pr_labels():
         post_acknowledging_comment(github_client, repo_name, pr_number)
     
     try:
-        app_json = get_app_json_from_repo(github_client, repo_name, pr_number)
-        if app_json:
-            is_certified = app_json.get("publisher") == "Splunk"
-            
+        # Resolve app metadata in a format-agnostic way so SDK apps (which have
+        # no committed manifest) are handled identically to traditional apps.
+        metadata, is_new_app = get_app_context(github_client, repo_name, pr_number)
+
+        if metadata is None:
+            logging.info(
+                "No app marker found for %s (not an app PR); skipping support "
+                "label and Jira creation.",
+                repo_name,
+            )
+        else:
+            is_certified = determine_is_certified(metadata, is_new_app)
+            logging.info(
+                "App %s: new_app=%s, format=%s, certified=%s",
+                repo_name, is_new_app, metadata.get("format"), is_certified,
+            )
+
             # Add certification label if not already present
-            if (CERTIFIED_LABEL not in existing_labels and 
-                NOT_CERTIFIED_LABEL not in existing_labels):
+            if (CERTIFIED_LABEL not in existing_labels and
+                    NOT_CERTIFIED_LABEL not in existing_labels):
                 labels_to_add.append(CERTIFIED_LABEL if is_certified else NOT_CERTIFIED_LABEL)
-                logging.info(f"Adding label {labels_to_add[-1]} for app {repo_name}")
-            
+                logging.info("Adding label %s for app %s", labels_to_add[-1], repo_name)
+
             # Create JIRA ticket for external contributors
-            if (is_external_contributor and 
-                not any(JIRA_LABEL_PATTERN.match(lb) for lb in existing_labels)):
-                
+            if (is_external_contributor and
+                    not any(JIRA_LABEL_PATTERN.match(lb) for lb in existing_labels)):
+
                 jira_ticket = create_jira_ticket(
-                    jira_user, jira_api_key, 
+                    jira_user, jira_api_key,
                     repo_name.split('/')[-1],
-                    is_certified, pr
+                    is_certified, pr,
+                    is_new_app=is_new_app,
                 )
                 if jira_ticket:
                     labels_to_add.append(jira_ticket)
                     logging.info("Adding new JIRA ticket label %s", jira_ticket)
     except Exception as e:
-        raise RuntimeError(f"Error when processing app JSON: {e}") from e
+        raise RuntimeError(f"Error when processing app metadata: {e}") from e
     
     # Apply labels
     if labels_to_add:

--- a/.github/actions/pr-labeling/assign_pr_labels.py
+++ b/.github/actions/pr-labeling/assign_pr_labels.py
@@ -3,6 +3,7 @@
 Assigns labels to PRs based on properties of the PR
 """
 
+import ast
 import json
 import logging
 import os
@@ -219,10 +220,56 @@ def _read_traditional_manifest_at_ref(repo, ref):
     }
 
 
-def _grab_app_kwarg(block, key):
-    """Pull a string keyword value from the ``App(...)`` constructor block."""
-    match = re.search(rf"""{key}\s*=\s*["']([^"']*)["']""", block)
-    return match.group(1) if match else None
+def _module_string_constants(tree):
+    """Map top-level ``NAME = "literal"`` assignments to their string values.
+
+    Lets us resolve kwargs that reference module constants (e.g. real apps
+    write ``appid=APP_ID`` / ``name=APP_NAME``) rather than inline literals.
+    """
+    constants = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            targets, value = node.targets, node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            targets, value = [node.target], node.value
+        else:
+            continue
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    constants[target.id] = value.value
+    return constants
+
+
+def _find_app_call(tree):
+    """Return the ``ast.Call`` node for ``App(...)``, or None.
+
+    Matches the constructor by callee name, so chained calls like
+    ``App(...).enable_webhooks(...)`` and unrelated ``name=`` kwargs on action
+    decorators are handled correctly by AST structure (not text proximity).
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "App":
+            return node
+    return None
+
+
+def _app_kwarg(call, key, constants):
+    """Resolve a string kwarg from the ``App(...)`` call, or None.
+
+    Accepts inline string literals and references to module-level string
+    constants; anything else (computed expressions) is left as None.
+    """
+    for keyword in call.keywords:
+        if keyword.arg != key:
+            continue
+        value = keyword.value
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            return value.value
+        if isinstance(value, ast.Name):
+            return constants.get(value.id)
+        return None
+    return None
 
 
 def _read_sdk_manifest_at_ref(repo, ref):
@@ -230,19 +277,25 @@ def _read_sdk_manifest_at_ref(repo, ref):
 
     SDK apps do not commit a manifest; ``publisher``/``appid``/``name`` are
     declared as keyword arguments to ``App(...)`` in the authored entry point.
+    Parsed via AST so nested parens, multi-line calls, and constant references
+    are handled robustly.
     """
     try:
         raw = repo.get_contents(SDK_APP_ENTRY, ref=ref).decoded_content.decode("utf-8")
     except Exception:
         return None
-    # Isolate the App(...) call so unrelated name= kwargs (e.g. on action
-    # decorators) are not picked up. The constructor has no nested parens.
-    call = re.search(r"App\((.*?)\)", raw, re.DOTALL)
-    block = call.group(1) if call else raw
+    try:
+        tree = ast.parse(raw)
+    except SyntaxError:
+        return None
+    call = _find_app_call(tree)
+    if call is None:
+        return None
+    constants = _module_string_constants(tree)
     return {
-        "publisher": _grab_app_kwarg(block, "publisher"),
-        "appid": _grab_app_kwarg(block, "appid"),
-        "name": _grab_app_kwarg(block, "name"),
+        "publisher": _app_kwarg(call, "publisher", constants),
+        "appid": _app_kwarg(call, "appid", constants),
+        "name": _app_kwarg(call, "name", constants),
         "format": "sdk",
     }
 
@@ -327,13 +380,12 @@ def determine_is_certified(metadata, is_new_app):
     Existing -> Splunkbase ``support`` field decides; falls back to the
                 publisher field only when Splunkbase is undecided.
     """
-    publisher = (metadata or {}).get("publisher")
-    publisher_supported = publisher == CERTIFIED_PUBLISHER
+    publisher_supported = metadata.get("publisher") == CERTIFIED_PUBLISHER
 
     if is_new_app:
         return publisher_supported
 
-    sb_supported = splunkbase_is_supported((metadata or {}).get("appid"))
+    sb_supported = splunkbase_is_supported(metadata.get("appid"))
     if sb_supported is None:
         logging.info("Falling back to publisher field for support decision.")
         return publisher_supported
@@ -393,8 +445,6 @@ def assign_pr_labels():
         post_acknowledging_comment(github_client, repo_name, pr_number)
     
     try:
-        # Resolve app metadata in a format-agnostic way so SDK apps (which have
-        # no committed manifest) are handled identically to traditional apps.
         metadata, is_new_app = get_app_context(github_client, repo_name, pr_number)
 
         if metadata is None:

--- a/.github/actions/pr-labeling/test_assign_pr_labels.py
+++ b/.github/actions/pr-labeling/test_assign_pr_labels.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""Unit tests for assign_pr_labels.
+
+These tests stub out the ``requests`` and ``github`` dependencies and never
+touch the network, GitHub, Jira, or Splunkbase, so they are safe to run
+locally with a plain ``python3 test_assign_pr_labels.py`` (no pip installs
+required).
+"""
+
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+def _install_fake_dependencies():
+    """Provide minimal stand-ins for the third party imports in the target."""
+    if "requests" not in sys.modules:
+        requests_mod = types.ModuleType("requests")
+        exceptions_mod = types.ModuleType("requests.exceptions")
+
+        class RequestException(Exception):
+            pass
+
+        exceptions_mod.RequestException = RequestException
+        requests_mod.exceptions = exceptions_mod
+
+        def _unconfigured_call(*_args, **_kwargs):
+            raise AssertionError("requests.get/post must be patched within each test")
+
+        requests_mod.post = _unconfigured_call
+        requests_mod.get = _unconfigured_call
+        sys.modules["requests"] = requests_mod
+        sys.modules["requests.exceptions"] = exceptions_mod
+
+    if "github" not in sys.modules:
+        github_mod = types.ModuleType("github")
+
+        class Github:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+        github_mod.Github = Github
+        sys.modules["github"] = github_mod
+
+
+_install_fake_dependencies()
+
+_MODULE_PATH = Path(__file__).with_name("assign_pr_labels.py")
+_spec = importlib.util.spec_from_file_location("assign_pr_labels", _MODULE_PATH)
+assign_pr_labels = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(assign_pr_labels)
+
+
+class FakeResponse:
+    def __init__(self, status_code, json_data=None, text=""):
+        self.status_code = status_code
+        self._json = json_data or {}
+        self.text = text
+
+    def json(self):
+        return self._json
+
+
+class FakePR:
+    def __init__(self, html_url="https://github.com/org/app/pull/1", body="desc"):
+        self.html_url = html_url
+        self.body = body
+
+
+class FakeContentFile:
+    def __init__(self, name, decoded=b"{}"):
+        self.name = name
+        self.decoded_content = decoded
+
+
+def _sdk_app_py(publisher=None, appid=None, name=None):
+    """Render an SDK ``src/app.py`` with an ``App(...)`` call like real apps."""
+    lines = ["from soar_sdk.app import App", "", "app = App("]
+    if name is not None:
+        lines.append(f'    name="{name}",')
+    lines.append('    app_type="sandbox",')
+    lines.append('    product_vendor="vendor",')
+    if publisher is not None:
+        lines.append(f'    publisher="{publisher}",')
+    if appid is not None:
+        lines.append(f'    appid="{appid}",')
+    lines += [
+        ")",
+        "",
+        '@app.action(name="some action", identifier="act")',
+        "def act():",
+        "    pass",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+class FakeRepo:
+    """Mimics enough of a PyGithub Repository for metadata reading.
+
+    ``default`` and ``head`` describe what exists at each ref. Each is either
+    None (no app), or a dict:
+      {"kind": "traditional", "manifest": {...}}
+      {"kind": "sdk", "app": {"publisher": ..., "appid": ..., "name": ...}}
+    """
+
+    def __init__(self, default=None, head=None):
+        self.default_branch = "main"
+        self._default = default
+        self._head = head
+
+    def _spec_for_ref(self, ref):
+        return self._default if ref == self.default_branch else self._head
+
+    def get_contents(self, path, ref=None):
+        spec = self._spec_for_ref(ref)
+        if spec is None:
+            raise RuntimeError(f"nothing at ref {ref}")
+        kind = spec.get("kind")
+
+        if path == "":  # top-level directory listing
+            if kind == "traditional":
+                return [FakeContentFile("app.json")]
+            return [FakeContentFile("pyproject.toml"), FakeContentFile("README.md")]
+
+        if kind == "traditional" and path.endswith(".json"):
+            return FakeContentFile(path, json.dumps(spec["manifest"]).encode("utf-8"))
+
+        if kind == "sdk" and path == assign_pr_labels.SDK_APP_ENTRY:
+            return FakeContentFile(path, _sdk_app_py(**spec.get("app", {})).encode("utf-8"))
+
+        raise RuntimeError(f"no {path} at ref {ref}")
+
+    def get_pull(self, _number):
+        return types.SimpleNamespace(head=types.SimpleNamespace(sha="deadbeef"))
+
+
+class FakeClient:
+    def __init__(self, repo):
+        self._repo = repo
+
+    def get_repo(self, _name):
+        return self._repo
+
+
+class FakePullRequest:
+    def __init__(self, login="extuser"):
+        self.user = types.SimpleNamespace(login=login)
+        self.labels = []
+        self.set_labels_args = None
+
+    def set_labels(self, *labels):
+        self.set_labels_args = labels
+
+    def create_issue_comment(self, _comment):
+        pass
+
+
+def _fake_myself(account_id="acc-123", status=200):
+    def _get(_url, headers=None, auth=None, timeout=None):
+        if status >= 400:
+            return FakeResponse(status, text="myself failed")
+        return FakeResponse(status, {"accountId": account_id})
+
+    return _get
+
+
+class CreateJiraTicketTests(unittest.TestCase):
+    def test_missing_credentials_returns_none(self):
+        self.assertIsNone(
+            assign_pr_labels.create_jira_ticket("", "", "app", False, FakePR())
+        )
+
+    def test_new_app_developer_supported_payload(self):
+        captured = {}
+
+        def fake_post(_url, headers=None, json=None, auth=None, timeout=None):
+            captured["json"] = json
+            return FakeResponse(201, {"key": "PAPP-123"})
+
+        with mock.patch.object(assign_pr_labels.requests, "get", side_effect=_fake_myself()), \
+                mock.patch.object(assign_pr_labels.requests, "post", side_effect=fake_post):
+            key = assign_pr_labels.create_jira_ticket(
+                "user", "key", "myapp", is_certified=False, pr_info=FakePR(), is_new_app=True
+            )
+
+        self.assertEqual(key, "PAPP-123")
+        fields = captured["json"]["fields"]
+        self.assertTrue(fields["summary"].startswith(assign_pr_labels.NEW_APP_SUMMARY_PREFIX))
+        self.assertIn("Developer-supported", fields["summary"])
+        self.assertIn(assign_pr_labels.NOT_CERTIFIED_LABEL, fields["labels"])
+        # The required reporter field must be set explicitly to the auth'd account.
+        self.assertEqual(fields["reporter"], {"accountId": "acc-123"})
+
+    def test_certified_summary_has_no_new_app_prefix(self):
+        captured = {}
+
+        def fake_post(_url, headers=None, json=None, auth=None, timeout=None):
+            captured["json"] = json
+            return FakeResponse(201, {"key": "PAPP-200"})
+
+        with mock.patch.object(assign_pr_labels.requests, "get", side_effect=_fake_myself()), \
+                mock.patch.object(assign_pr_labels.requests, "post", side_effect=fake_post):
+            assign_pr_labels.create_jira_ticket(
+                "user", "key", "myapp", is_certified=True, pr_info=FakePR(), is_new_app=False
+            )
+
+        summary = captured["json"]["fields"]["summary"]
+        self.assertFalse(summary.startswith(assign_pr_labels.NEW_APP_SUMMARY_PREFIX))
+        self.assertIn("Splunk-supported", summary)
+
+    def test_400_logs_body_and_returns_none(self):
+        attempts = []
+
+        def fake_post(_url, headers=None, json=None, auth=None, timeout=None):
+            attempts.append(json["fields"])
+            return FakeResponse(400, text='{"errors":{"reporter":"reporter is required."}}')
+
+        with mock.patch.object(assign_pr_labels.requests, "get", side_effect=_fake_myself()), \
+                mock.patch.object(assign_pr_labels.requests, "post", side_effect=fake_post):
+            with self.assertLogs(level="ERROR") as log:
+                key = assign_pr_labels.create_jira_ticket("u", "k", "app", True, FakePR())
+
+        self.assertIsNone(key)
+        # Exactly one create attempt (no speculative fallback retries).
+        self.assertEqual(len(attempts), 1)
+        # The real Jira validation body is surfaced in the logs.
+        self.assertTrue(any("reporter is required" in line for line in log.output))
+
+    def test_reporter_omitted_when_myself_unavailable(self):
+        captured = {}
+
+        def fake_post(_url, headers=None, json=None, auth=None, timeout=None):
+            captured["json"] = json
+            return FakeResponse(201, {"key": "PAPP-300"})
+
+        with mock.patch.object(
+            assign_pr_labels.requests, "get", side_effect=_fake_myself(status=401)
+        ), mock.patch.object(assign_pr_labels.requests, "post", side_effect=fake_post):
+            with self.assertLogs(level="WARNING"):
+                key = assign_pr_labels.create_jira_ticket("u", "k", "app", False, FakePR())
+
+        self.assertEqual(key, "PAPP-300")
+        self.assertNotIn("reporter", captured["json"]["fields"])
+
+
+class AppContextTests(unittest.TestCase):
+    """Format-agnostic metadata + new-app detection (traditional and SDK)."""
+
+    def test_traditional_existing_app_is_not_new(self):
+        repo = FakeRepo(
+            default={"kind": "traditional", "manifest": {"publisher": "Splunk", "appid": "guid-1"}},
+            head={"kind": "traditional", "manifest": {"publisher": "Splunk", "appid": "guid-1"}},
+        )
+        meta, is_new = assign_pr_labels.get_app_context(FakeClient(repo), "org/app", 1)
+        self.assertFalse(is_new)
+        self.assertEqual(meta["format"], "traditional")
+        self.assertEqual(meta["publisher"], "Splunk")
+        self.assertEqual(meta["appid"], "guid-1")
+
+    def test_traditional_new_app_only_in_head(self):
+        repo = FakeRepo(
+            default=None,
+            head={"kind": "traditional", "manifest": {"publisher": "Acme", "appid": "guid-2"}},
+        )
+        meta, is_new = assign_pr_labels.get_app_context(FakeClient(repo), "org/app", 1)
+        self.assertTrue(is_new)
+        self.assertEqual(meta["publisher"], "Acme")
+
+    def test_sdk_new_app_reads_app_py(self):
+        repo = FakeRepo(
+            default=None,
+            head={"kind": "sdk", "app": {"publisher": "Splunk", "appid": "c46c", "name": "urlscan.io"}},
+        )
+        meta, is_new = assign_pr_labels.get_app_context(FakeClient(repo), "org/urlscan", 1)
+        self.assertTrue(is_new)
+        self.assertEqual(meta["format"], "sdk")
+        self.assertEqual(meta["publisher"], "Splunk")
+        self.assertEqual(meta["appid"], "c46c")
+        self.assertEqual(meta["name"], "urlscan.io")
+
+    def test_sdk_existing_app_is_not_new(self):
+        repo = FakeRepo(
+            default={"kind": "sdk", "app": {"publisher": "Acme", "appid": "c99"}},
+            head={"kind": "sdk", "app": {"publisher": "Acme", "appid": "c99"}},
+        )
+        meta, is_new = assign_pr_labels.get_app_context(FakeClient(repo), "org/urlscan", 1)
+        self.assertFalse(is_new)
+        self.assertEqual(meta["appid"], "c99")
+
+    def test_no_app_anywhere(self):
+        repo = FakeRepo(default=None, head=None)
+        meta, is_new = assign_pr_labels.get_app_context(FakeClient(repo), "org/docs", 1)
+        self.assertIsNone(meta)
+        self.assertFalse(is_new)
+
+
+class DetermineIsCertifiedTests(unittest.TestCase):
+    def test_new_app_publisher_splunk_is_certified(self):
+        meta = {"publisher": "Splunk", "appid": "x"}
+        self.assertTrue(assign_pr_labels.determine_is_certified(meta, is_new_app=True))
+
+    def test_new_app_publisher_other_is_not_certified(self):
+        meta = {"publisher": "Acme", "appid": "x"}
+        self.assertFalse(assign_pr_labels.determine_is_certified(meta, is_new_app=True))
+
+    def test_existing_app_uses_splunkbase_when_decided(self):
+        meta = {"publisher": "Acme", "appid": "guid"}
+        with mock.patch.object(assign_pr_labels, "splunkbase_is_supported", return_value=True):
+            self.assertTrue(assign_pr_labels.determine_is_certified(meta, is_new_app=False))
+        with mock.patch.object(assign_pr_labels, "splunkbase_is_supported", return_value=False):
+            self.assertFalse(assign_pr_labels.determine_is_certified(meta, is_new_app=False))
+
+    def test_existing_app_falls_back_to_publisher_when_splunkbase_undecided(self):
+        meta = {"publisher": "Splunk", "appid": "guid"}
+        with mock.patch.object(assign_pr_labels, "splunkbase_is_supported", return_value=None):
+            self.assertTrue(assign_pr_labels.determine_is_certified(meta, is_new_app=False))
+
+
+class SplunkbaseLookupTests(unittest.TestCase):
+    def test_skips_without_credentials(self):
+        with mock.patch.dict(assign_pr_labels.os.environ, {}, clear=True):
+            with self.assertLogs(level="WARNING"):
+                self.assertIsNone(assign_pr_labels.splunkbase_is_supported("guid"))
+
+
+class AssignPrLabelsTests(unittest.TestCase):
+    BASE_ENV = {
+        "GITHUB_TOKEN": "token",
+        "REPO_NAME": "org/myapp",
+        "PR_NUMBER": "1",
+        "JIRA_USER": "u",
+        "JIRA_API_KEY": "k",
+    }
+
+    def _run_with(self, pr, *, is_internal, metadata, is_new_app, create_jira_mock,
+                  splunkbase_supported=None):
+        repo = mock.Mock()
+        repo.get_pull.return_value = pr
+        client = mock.Mock()
+        client.get_repo.return_value = repo
+
+        with mock.patch.dict(assign_pr_labels.os.environ, self.BASE_ENV, clear=False), \
+                mock.patch.object(assign_pr_labels, "Github", return_value=client), \
+                mock.patch.object(
+                    assign_pr_labels, "check_if_internal_contributor", return_value=is_internal
+                ), \
+                mock.patch.object(
+                    assign_pr_labels, "get_app_context", return_value=(metadata, is_new_app)
+                ), \
+                mock.patch.object(
+                    assign_pr_labels, "splunkbase_is_supported", return_value=splunkbase_supported
+                ), \
+                mock.patch.object(assign_pr_labels, "post_acknowledging_comment"), \
+                mock.patch.object(
+                    assign_pr_labels, "create_jira_ticket", side_effect=create_jira_mock
+                ):
+            assign_pr_labels.assign_pr_labels()
+
+    def test_external_new_app_non_splunk_publisher_is_developer_supported(self):
+        pr = FakePullRequest(login="extuser")
+        captured = {}
+
+        def fake_create(_juser, _jkey, _app, is_certified, _pr_info, is_new_app=False):
+            captured["is_certified"] = is_certified
+            captured["is_new_app"] = is_new_app
+            return "PAPP-500"
+
+        # Realistic external new app: publisher is the contributor, not Splunk.
+        self._run_with(
+            pr,
+            is_internal=False,
+            metadata={"publisher": "Acme", "appid": "guid", "format": "sdk"},
+            is_new_app=True,
+            create_jira_mock=fake_create,
+        )
+
+        self.assertFalse(captured["is_certified"])
+        self.assertTrue(captured["is_new_app"])
+        self.assertIn(assign_pr_labels.EXTERNAL_CONTRIBUTOR_LABEL, pr.set_labels_args)
+        self.assertIn(assign_pr_labels.NOT_CERTIFIED_LABEL, pr.set_labels_args)
+        self.assertIn("PAPP-500", pr.set_labels_args)
+        self.assertNotIn(assign_pr_labels.CERTIFIED_LABEL, pr.set_labels_args)
+
+    def test_external_sdk_new_app_is_processed(self):
+        """Regression: SDK apps (no committed manifest) must still get labelled."""
+        pr = FakePullRequest(login="extuser")
+
+        def fake_create(*_args, **_kwargs):
+            return "PAPP-777"
+
+        self._run_with(
+            pr,
+            is_internal=False,
+            metadata={"publisher": "Acme", "appid": "guid", "format": "sdk"},
+            is_new_app=True,
+            create_jira_mock=fake_create,
+        )
+
+        self.assertIn("PAPP-777", pr.set_labels_args)
+        self.assertIn(assign_pr_labels.NOT_CERTIFIED_LABEL, pr.set_labels_args)
+
+    def test_external_existing_app_supported_via_splunkbase(self):
+        pr = FakePullRequest(login="extuser")
+        captured = {}
+
+        def fake_create(_juser, _jkey, _app, is_certified, _pr_info, is_new_app=False):
+            captured["is_certified"] = is_certified
+            return "PAPP-600"
+
+        self._run_with(
+            pr,
+            is_internal=False,
+            metadata={"publisher": "Acme", "appid": "guid", "format": "traditional"},
+            is_new_app=False,
+            create_jira_mock=fake_create,
+            splunkbase_supported=True,
+        )
+
+        self.assertTrue(captured["is_certified"])
+        self.assertIn(assign_pr_labels.CERTIFIED_LABEL, pr.set_labels_args)
+        self.assertIn("PAPP-600", pr.set_labels_args)
+
+    def test_non_app_pr_gets_no_support_label_or_jira(self):
+        pr = FakePullRequest(login="extuser")
+        jira_calls = []
+
+        def fake_create(*_args, **_kwargs):
+            jira_calls.append(_args)
+            return "SHOULD-NOT-HAPPEN"
+
+        self._run_with(
+            pr,
+            is_internal=False,
+            metadata=None,
+            is_new_app=False,
+            create_jira_mock=fake_create,
+        )
+
+        # External label still applied, but no support label and no Jira.
+        self.assertIn(assign_pr_labels.EXTERNAL_CONTRIBUTOR_LABEL, pr.set_labels_args)
+        self.assertNotIn(assign_pr_labels.CERTIFIED_LABEL, pr.set_labels_args)
+        self.assertNotIn(assign_pr_labels.NOT_CERTIFIED_LABEL, pr.set_labels_args)
+        self.assertEqual(jira_calls, [])
+
+    def test_internal_certified_app_gets_supported_label_and_no_jira(self):
+        pr = FakePullRequest(login="internaluser")
+        jira_calls = []
+
+        def fake_create(*_args, **_kwargs):
+            jira_calls.append(_args)
+            return "SHOULD-NOT-HAPPEN"
+
+        self._run_with(
+            pr,
+            is_internal=True,
+            metadata={"publisher": "Splunk", "appid": "guid", "format": "traditional"},
+            is_new_app=False,
+            create_jira_mock=fake_create,
+            splunkbase_supported=True,
+        )
+
+        self.assertIn(assign_pr_labels.CERTIFIED_LABEL, pr.set_labels_args)
+        self.assertNotIn(assign_pr_labels.EXTERNAL_CONTRIBUTOR_LABEL, pr.set_labels_args)
+        self.assertEqual(jira_calls, [], "Jira ticket must not be created for internal PRs")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/actions/pr-labeling/test_assign_pr_labels.py
+++ b/.github/actions/pr-labeling/test_assign_pr_labels.py
@@ -299,6 +299,79 @@ class AppContextTests(unittest.TestCase):
         self.assertFalse(is_new)
 
 
+class _RawSdkRepo:
+    """Returns arbitrary ``src/app.py`` text so we can test the AST parser."""
+
+    def __init__(self, raw):
+        self._raw = raw
+
+    def get_contents(self, path, ref=None):
+        if path == assign_pr_labels.SDK_APP_ENTRY:
+            return FakeContentFile(path, self._raw.encode("utf-8"))
+        raise RuntimeError("only app.py available")
+
+
+class SdkManifestParsingTests(unittest.TestCase):
+    """AST-based parsing of src/app.py (robust to constants/chaining/decorators)."""
+
+    def _read(self, raw):
+        return assign_pr_labels._read_sdk_manifest_at_ref(_RawSdkRepo(raw), "ref")
+
+    def test_resolves_module_constants_and_chained_call(self):
+        # Mirrors microsoft365: appid/name reference module constants and the
+        # constructor is chained with .enable_webhooks(...).
+        raw = (
+            "from soar_sdk.app import App\n"
+            'APP_NAME = "Microsoft 365 (MS Graph)"\n'
+            'APP_ID = "abc-123"\n'
+            "app = App(\n"
+            "    name=APP_NAME,\n"
+            '    publisher="Splunk",\n'
+            "    appid=APP_ID,\n"
+            "    asset_cls=Asset,\n"
+            ").enable_webhooks(default_requires_auth=False)\n"
+        )
+        meta = self._read(raw)
+        self.assertEqual(meta["format"], "sdk")
+        self.assertEqual(meta["publisher"], "Splunk")
+        self.assertEqual(meta["appid"], "abc-123")
+        self.assertEqual(meta["name"], "Microsoft 365 (MS Graph)")
+
+    def test_ignores_action_decorator_name_kwarg(self):
+        raw = (
+            "from soar_sdk.app import App\n"
+            "app = App(\n"
+            '    name="Real App",\n'
+            '    publisher="Acme",\n'
+            "    asset_cls=Asset,\n"
+            ")\n"
+            '@app.action(name="some action", identifier="act")\n'
+            "def act():\n"
+            "    pass\n"
+        )
+        meta = self._read(raw)
+        self.assertEqual(meta["name"], "Real App")
+        self.assertEqual(meta["publisher"], "Acme")
+
+    def test_computed_expression_value_is_none(self):
+        raw = (
+            "from soar_sdk.app import App\n"
+            "app = App(\n"
+            '    name="X",\n'
+            "    publisher=os.environ['P'],\n"
+            ")\n"
+        )
+        meta = self._read(raw)
+        self.assertEqual(meta["name"], "X")
+        self.assertIsNone(meta["publisher"])
+
+    def test_no_app_call_returns_none(self):
+        self.assertIsNone(self._read("x = 1\n"))
+
+    def test_syntax_error_returns_none(self):
+        self.assertIsNone(self._read("app = App(\n"))
+
+
 class DetermineIsCertifiedTests(unittest.TestCase):
     def test_new_app_publisher_splunk_is_certified(self):
         meta = {"publisher": "Splunk", "appid": "x"}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,6 +21,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           jira-user: ${{ secrets.JIRA_USER }}
           jira-api-key: ${{ secrets.JIRA_API_KEY }}
+          splunkbase-user: ${{ secrets.splunkbase_user }}
+          splunkbase-password: ${{ secrets.splunkbase_password }}
           repo-name: ${{ github.repository }}
           pr-number: ${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
## Summary
- create PAPP Jira tickets reliably for external contributor PRs by setting `reporter` to the authenticated Jira account and logging Jira validation bodies on failure
- detect traditional and SDK app metadata, including new apps added only in the PR head, and prefix Jira summaries with `[New App]`
- classify existing apps from Splunkbase support data when available, pass Splunkbase secrets into the action, and cover behavior with mocked tests

## Root Cause
PAPP Epic creation was returning `400 Bad Request` because the CI Jira service account did not supply the required `reporter` field. The old action only logged the generic HTTPError, so the field-level body was hidden and no `PAPP-*` label was added after creation failed. SDK apps also lacked committed JSON manifests, so the labeler could miss app metadata.

## Validation
- `python3 .github/actions/pr-labeling/test_assign_pr_labels.py`
- `PYTHONPYCACHEPREFIX=/private/tmp/codex-pycache python3 -m py_compile .github/actions/pr-labeling/assign_pr_labels.py .github/actions/pr-labeling/test_assign_pr_labels.py`
- `git diff --check`