### PR TITLE
revert image upgrade for now

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -172,7 +172,7 @@ jobs:
   publish:
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
-      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:41690eb58c44f2ae281de68d8d765ff24c35eee2
+      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
     needs: build
     outputs:
       return_code: ${{ steps.set-outputs.outputs.return_code }}
@@ -220,7 +220,7 @@ jobs:
   metrics:
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
-      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:41690eb58c44f2ae281de68d8d765ff24c35eee2
+      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
     needs: publish
     if: always()
     steps:
@@ -243,7 +243,7 @@ jobs:
   notify-slack:
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
-      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:41690eb58c44f2ae281de68d8d765ff24c35eee2
+      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
     needs: publish
     if: always() && vars.SEND_RELEASE_MESSAGE == 'true' && (needs.publish.outputs.return_code == '0' || needs.publish.outputs.return_code == '2')
     steps:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -72,7 +72,7 @@ jobs:
   security-scans:
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
-      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:41690eb58c44f2ae281de68d8d765ff24c35eee2
+      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
     needs: detect-app-type
     env:
       IS_SDKFIED: ${{ needs.detect-app-type.outputs.is_sdkfied }}
@@ -110,7 +110,7 @@ jobs:
   compile:
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
-      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:41690eb58c44f2ae281de68d8d765ff24c35eee2
+      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
     needs: detect-app-type
     env:
       IS_SDKFIED: ${{ needs.detect-app-type.outputs.is_sdkfied }}
@@ -142,7 +142,7 @@ jobs:
   build:
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
-      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:41690eb58c44f2ae281de68d8d765ff24c35eee2
+      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
     needs: [compile, detect-app-type]
     env:
       IS_SDKFIED: ${{ needs.detect-app-type.outputs.is_sdkfied }}
@@ -232,7 +232,7 @@ jobs:
   test-coverage:
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
-      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:41690eb58c44f2ae281de68d8d765ff24c35eee2
+      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
     needs: [test-setup, detect-app-type]
     env:
       IS_SDKFIED: ${{ needs.detect-app-type.outputs.is_sdkfied }}
@@ -274,7 +274,7 @@ jobs:
   sanity-test:
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
-      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:41690eb58c44f2ae281de68d8d765ff24c35eee2
+      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
     needs: test-setup
     if: ${{ needs.test-setup.outputs.publisher == 'Splunk' }}
     strategy:
@@ -335,7 +335,7 @@ jobs:
   aws-sanity-test:
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
-      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:41690eb58c44f2ae281de68d8d765ff24c35eee2
+      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
     needs: test-setup
     if: ${{ needs.test-setup.outputs.publisher == 'Splunk' && contains(github.event.repository.name, 'aws') }}
     strategy:
@@ -412,7 +412,7 @@ jobs:
   integration-test:
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
-      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:41690eb58c44f2ae281de68d8d765ff24c35eee2
+      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
     needs: test-setup
     if: ${{ needs.test-setup.outputs.publisher == 'Splunk' }}
     env:


### PR DESCRIPTION
Reverting image upgrade for now. This new package has some other package upgrades that would break app tests without the assets/app tests changes (which are not being merged until next week until we have GA signoff)