### PR TITLE
fix: skip unsupported legacy compile targets

### DIFF
--- a/.github/utils/compile_app.py
+++ b/.github/utils/compile_app.py
@@ -1,17 +1,21 @@
+import json
+import logging
 import os
-from pathlib import Path
+import random
 import re
 import socket
 import string
-import random
-import logging
 from contextlib import contextmanager
-from typing import Union
 from collections.abc import Iterator
+from pathlib import Path
+from typing import Union
 
 import backoff
 import paramiko
 from scp import SCPClient
+
+from utils import find_app_json_name
+from utils.version_compat import supports_minimum_version
 
 ANSI_ESCAPE = re.compile(r"(\x1b|\x1B)(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 OUTPUT = re.compile(r"Output\:([^\x1b]*?)Error output\:")
@@ -21,6 +25,39 @@ TEST_DIRECTORY = "/home/phantom/app_tests"
 RANDOM_STRING = "/{}/".format(
     "".join(random.choices(string.ascii_uppercase + string.ascii_lowercase, k=7))
 )
+
+
+def get_min_phantom_version(local_app_path: Path) -> str:
+    local_app_path = Path(local_app_path)
+    json_filenames = [path.name for path in local_app_path.glob("*.json")]
+    app_json_name = (
+        "manifest.json" if "manifest.json" in json_filenames else find_app_json_name(json_filenames)
+    )
+
+    with (local_app_path / app_json_name).open() as app_json_file:
+        return json.load(app_json_file)["min_phantom_version"]
+
+
+def is_local_app_compatible(
+    local_app_path: Path,
+    phantom_ip: str,
+    phantom_username: str,
+    phantom_password: str,
+) -> bool:
+    try:
+        min_phantom_version = get_min_phantom_version(local_app_path)
+        return supports_minimum_version(
+            min_phantom_version,
+            phantom_ip,
+            phantom_username,
+            phantom_password,
+        )
+    except Exception as error:
+        logging.warning(
+            "Version compatibility check failed for traditional app, defaulting to compatible: %s",
+            error,
+        )
+        return True
 
 
 def compile_app(
@@ -109,6 +146,20 @@ def run_compile(
     }
 
     for version, host in hosts.items():
+        if not is_local_app_compatible(
+            local_app_path,
+            host,
+            phantom_username,
+            phantom_password,
+        ):
+            message = (
+                f"Skipping compile on {version}: app's min_phantom_version "
+                "is not supported by this instance"
+            )
+            logging.info(message)
+            results[version] = {"success": True, "message": [message]}
+            continue
+
         client = paramiko.SSHClient()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         try:

--- a/.github/utils/test_compile_app.py
+++ b/.github/utils/test_compile_app.py
@@ -1,0 +1,72 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from utils import compile_app
+
+
+class CompileAppVersionCompatibilityTest(unittest.TestCase):
+    def test_reads_minimum_version_from_traditional_app_json(self):
+        with tempfile.TemporaryDirectory() as temp_directory:
+            app_path = Path(temp_directory)
+            (app_path / "example_postman_collection.json").write_text("{}")
+            (app_path / "example.json").write_text(json.dumps({"min_phantom_version": "8.6.0"}))
+
+            self.assertEqual(compile_app.get_min_phantom_version(app_path), "8.6.0")
+
+    @mock.patch.object(compile_app, "supports_minimum_version", return_value=False)
+    def test_uses_shared_version_comparison(self, supports_minimum_version):
+        with tempfile.TemporaryDirectory() as temp_directory:
+            app_path = Path(temp_directory)
+            (app_path / "example.json").write_text(json.dumps({"min_phantom_version": "8.6.0"}))
+
+            compatible = compile_app.is_local_app_compatible(
+                app_path, "phantom.example", "phantom", "password"
+            )
+
+        self.assertFalse(compatible)
+        supports_minimum_version.assert_called_once_with(
+            "8.6.0", "phantom.example", "phantom", "password"
+        )
+
+    @mock.patch.object(
+        compile_app,
+        "get_min_phantom_version",
+        side_effect=ValueError("missing app JSON"),
+    )
+    def test_version_check_fails_open(self, _get_min_phantom_version):
+        self.assertTrue(
+            compile_app.is_local_app_compatible(
+                Path("/missing"), "phantom.example", "phantom", "password"
+            )
+        )
+
+    @mock.patch.object(compile_app.paramiko, "SSHClient")
+    @mock.patch.object(compile_app, "is_local_app_compatible", return_value=False)
+    def test_skips_unsupported_instances(self, _is_compatible, ssh_client):
+        results = compile_app.run_compile(
+            "example",
+            Path("/example"),
+            "current.example",
+            "next.example",
+            "previous.example",
+            "phantom",
+            "password",
+        )
+
+        ssh_client.assert_not_called()
+        self.assertEqual(
+            set(results),
+            {
+                "current_phantom_version",
+                "next_phantom_version",
+                "previous_phantom_version",
+            },
+        )
+        self.assertTrue(all(result["success"] for result in results.values()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/utils/version_compat.py
+++ b/.github/utils/version_compat.py
@@ -71,8 +71,7 @@ def get_instance_version(phantom_ip, phantom_username, phantom_password):
     return resp.json()["version"]
 
 
-def is_compatible(tarball_path, phantom_ip, phantom_username, phantom_password):
-    min_phantom_version = get_min_phantom_version(tarball_path)
+def supports_minimum_version(min_phantom_version, phantom_ip, phantom_username, phantom_password):
     instance_version = get_instance_version(phantom_ip, phantom_username, phantom_password)
 
     logging.info(
@@ -84,15 +83,23 @@ def is_compatible(tarball_path, phantom_ip, phantom_username, phantom_password):
     return parse_version(instance_version) >= parse_version(min_phantom_version)
 
 
+def is_compatible(tarball_path, phantom_ip, phantom_username, phantom_password):
+    min_phantom_version = get_min_phantom_version(tarball_path)
+    return supports_minimum_version(
+        min_phantom_version,
+        phantom_ip,
+        phantom_username,
+        phantom_password,
+    )
+
+
 def main(args):
     try:
         compatible = is_compatible(
             args.tarball_path, args.phantom_ip, args.phantom_username, args.phantom_password
         )
     except Exception as e:
-        logging.warning(
-            "Version compatibility check failed, defaulting to compatible: %s", e
-        )
+        logging.warning("Version compatibility check failed, defaulting to compatible: %s", e)
         logging.warning(
             "Diagnostics: tarball_path=%r, cwd=%s, cwd_contents=%s",
             args.tarball_path,


### PR DESCRIPTION
Written by Codex.

PAPP: [PAPP-37947](https://splunk.atlassian.net/browse/PAPP-37947)
Unblocks: [crowdstrikeoauth PR #89](https://github.com/splunk-soar-connectors/crowdstrikeoauth/pull/89)

## Root cause

The minimum-SOAR-version gate added in #393 only protects SDKfied tarball installation and downstream sanity tests. Traditional connectors still enter `compile_app.py` directly and attempt compilation on every configured instance, including instances older than the app's `min_phantom_version`.

This caused CrowdStrike OAuth, which requires SOAR 8.6, to fail its compile gate on the previous SOAR 8.4 instance even though current and next compiled successfully.

## Changes

- Reuse the shared minimum-version comparison for traditional connectors.
- Read `min_phantom_version` from the traditional connector checkout before connecting over SSH.
- Treat an unsupported instance as an intentional successful skip.
- Preserve the existing fail-open behavior when compatibility detection itself fails.
- Add focused coverage for JSON discovery, shared comparison, fail-open behavior, and skipping all unsupported targets without opening SSH connections.

## Validation

- `pre-commit run --files .github/utils/compile_app.py .github/utils/version_compat.py .github/utils/test_compile_app.py`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.github uv run --with backoff --with paramiko --with scp --with requests --with packaging python .github/utils/test_compile_app.py` — 4 tests passed

Full-repository pre-commit additionally reports unrelated existing formatting changes and an unused `release_notes` assignment in `update_version.py`; those are deliberately excluded from this scoped fix.
