### PR TITLE
fix: use package-qualified compatibility import

### DIFF
--- a/.github/utils/version_compat.py
+++ b/.github/utils/version_compat.py
@@ -19,7 +19,7 @@ from requests.auth import HTTPBasicAuth
 
 sys.path.append(str(Path(__file__).parent.parent.resolve()))
 
-from api import ApiSession
+from utils.api import ApiSession
 from utils import find_app_json_name
 
 


### PR DESCRIPTION
## Summary

Fixes the package-qualified import used when `version_compat` is loaded through `utils.compile_app` in the legacy connector compile job.

The import merged in #397 worked when `version_compat.py` ran as a standalone script, but failed when the legacy compiler imported it as `utils.version_compat`:

`ModuleNotFoundError: No module named 'api'`

This blocked [crowdstrikeoauth#89](https://github.com/splunk-soar-connectors/crowdstrikeoauth/pull/89) before connector compilation began. Tracking ticket: [PAPP-37947](https://splunk.atlassian.net/browse/PAPP-37947).

## Validation

- all four compile utility unit tests pass with `PYTHONPATH=.github`
- changed-file pre-commit hooks pass
- imported through the same `utils.version_compat` package path used by CI

This pull request and its change were written entirely by Codex with AI assistance.
