### PR TITLE
fix(ci): import compile API session package

### DIFF
--- a/.github/utils/version_compat.py
+++ b/.github/utils/version_compat.py
@@ -19,7 +19,7 @@ from requests.auth import HTTPBasicAuth
 
 sys.path.append(str(Path(__file__).parent.parent.resolve()))
 
-from api import ApiSession
+from utils.api import ApiSession
 from utils import find_app_json_name
 
 


### PR DESCRIPTION
## Summary

- import `ApiSession` from the existing `utils.api` package
- restore central connector compile-job startup before connector code runs

## Tracking

- Epic: ESPM-5228
- Pilot blockers: PAPP-37959, PAPP-37960, PAPP-37962, PAPP-37964

## Verification

- `pytest -q .github/utils/test_compile_app.py` (4 passed)
- direct `utils.version_compat.ApiSession` import smoke test
- targeted pre-commit hooks
- `git diff --check`

Written by Codex.