### PR TITLE
feat(ci): run pytest for SDK connectors

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -60,6 +60,30 @@ jobs:
           echo "App detection completed"
         shell: bash
 
+  pytest:
+    runs-on: ubuntu-latest
+    needs: detect-app-type
+    if: needs.detect-app-type.outputs.is_sdkfied == 'true'
+    permissions:
+      contents: read
+    env:
+      UV_LOCK_DIRECTORY: ${{ needs.detect-app-type.outputs.uv_lock_directory }}
+    steps:
+      - name: Check out app repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Set up SDKfied app environment
+        uses: splunk-soar-connectors/.github/.github/actions/sdkfied-app-setup@main
+        with:
+          uv_lock_directory: ${{ env.UV_LOCK_DIRECTORY }}
+
+      - name: Run pytest
+        run: uv run --project "$UV_LOCK_DIRECTORY" pytest
+
   pre-commit:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Features

- Add a dedicated `pytest` job to the shared connector pull request workflow.
- Run repository unit tests only when the existing app-type detector finds an SDK app via `uv.lock`.
- Skip the entire job for traditional BaseConnector apps before checkout, environment setup, or pytest execution.
- Check out the immutable pull request SHA with read-only permissions and no persisted token.

### Validation

- SDK guinea pig: [splunk-soar-connectors/github#41](https://github.com/splunk-soar-connectors/github/pull/41)
- Live SDK canary: [successful workflow run](https://github.com/splunk-soar-connectors/github/actions/runs/29537514305)
  - SDK detection passed.
  - Shared SDK environment setup passed.
  - Pytest collected and passed all 4 repository tests on Linux.
- PR proof comment: [GitHub #41 validation details](https://github.com/splunk-soar-connectors/github/pull/41#issuecomment-4996933408)
- BaseConnector guinea pig: [splunk-soar-connectors/nistnvd#12](https://github.com/splunk-soar-connectors/nistnvd/pull/12)
  - The repository has no `uv.lock`, so detection returns `is_sdkfied=false`.
  - The job-level condition prevents the pytest job from starting.
- Repository pre-commit hooks passed.
- Actionlint passed after ignoring only the workflow's existing custom CodeBuild runner-label diagnostics.
- `git diff --check` passed.

### Manual Documentation

- [x] No manual connector documentation changes are required.

---

PR authored by Codex.