### PR TITLE
fix: stabilize semantic release preview setup

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -112,12 +112,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: splunk-soar-connectors/.github
+          ref: main
           path: dotgithub
 
       - name: Set up NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version: "24"
 
       - name: Install semantic-release dependencies
         run: npm install --global semantic-release @semantic-release/exec @semantic-release/git conventional-changelog-conventionalcommits


### PR DESCRIPTION
## Summary

- pin the shared `.github` checkout to `main` in the connector PR semantic-release preview job
- replace floating `lts/*` Node resolution with explicit Node 24

This avoids preview failures caused by GitHub API lookups for the default branch and floating Node metadata.

## Validation

- YAML parsing passed
- git diff --check passed

Authored by Codex.