### PR TITLE
fix: pass credentials to traditional compile checks

### DIFF
--- a/.github/actions/compile-app/action.yml
+++ b/.github/actions/compile-app/action.yml
@@ -38,7 +38,7 @@ runs:
         echo "Building SDKfied app using soarapps CLI"
         uv run soarapps package build .
         echo "SDKfied app build completed successfully"
-        
+
         TARBALL=$(find . -name "*.tgz" | head -1)
         TARBALL_NAME=$(basename "$TARBALL")
         TARBALL_ABS_PATH=$(readlink -f "$TARBALL")
@@ -76,6 +76,8 @@ runs:
 
     - name: Compile Traditional App
       if: inputs.is_sdkfied == 'false'
+      env:
+        PHANTOM_PASSWORD: ${{ inputs.phantom_password }}
       run: |
         set -e
         python ${{ github.action_path }}/compile_app_in_instance.py ${{ github.event.repository.name }} --app-repo-branch ${{ github.head_ref }} --current-phantom-ip ${{ inputs.current_phantom_ip }} --next-phantom-ip ${{ inputs.next_phantom_ip }} --previous-phantom-ip ${{ inputs.previous_phantom_ip }} --phantom-username ${{ inputs.phantom_username }}

--- a/.github/utils/test_compile_action.py
+++ b/.github/utils/test_compile_action.py
@@ -1,0 +1,14 @@
+import unittest
+from pathlib import Path
+
+
+class CompileActionTest(unittest.TestCase):
+    def test_traditional_compile_receives_phantom_password(self):
+        action_path = Path(__file__).parents[1] / "actions" / "compile-app" / "action.yml"
+        traditional_step = action_path.read_text().split("- name: Compile Traditional App", 1)[1]
+
+        self.assertIn("PHANTOM_PASSWORD: ${{ inputs.phantom_password }}", traditional_step)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Written by Codex.

PAPP: [PAPP-38037](https://splunk.atlassian.net/browse/PAPP-38037)
Unblocks: [RSA SecureID AM PR #24](https://github.com/splunk-soar-connectors/rsasecureidam/pull/24), [Zoom PR #36](https://github.com/splunk-soar-connectors/zoom/pull/36)

## Root cause

The traditional compile step did not export its required `phantom_password` input as `PHANTOM_PASSWORD`. `compile_app_in_instance.py` therefore used its fallback value `.` when the existing HTTP Basic-auth `/rest/version` check ran. The resulting HTTP 401 triggered the intended fail-open behavior and incorrectly attempted to compile connectors requiring SOAR 8.6 on the previous 8.4 instance.

Connectors whose minimum version is 8.4 or earlier were unaffected because their subsequent 8.4 compile succeeded, which obscured the missing credential.

## Changes

- Pass the configured password to the traditional compile process through its existing `PHANTOM_PASSWORD` environment variable.
- Add a regression test proving the traditional action step receives that input.
- Keep the established HTTP Basic-auth `/rest/version` implementation unchanged.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.github uv run --with backoff --with paramiko --with scp --with requests --with packaging python -m unittest -v utils.test_compile_action utils.test_compile_app` — 5 tests passed.
- Changed-file pre-commit hooks passed.
- `git diff --check` passed.
