### PR TITLE
fix: separate compile SSH and REST identities

### DIFF
--- a/.github/actions/compile-app/compile_app_in_instance.py
+++ b/.github/actions/compile-app/compile_app_in_instance.py
@@ -20,6 +20,7 @@ from utils import compile_app
 
 LOCAL_REPO_DIRECTORY = os.getenv("GITHUB_WORKSPACE", ".")
 PHANTOM_PASSWORD = os.getenv("PHANTOM_PASSWORD", ".")
+PHANTOM_REST_USERNAME = "soar_local_admin"
 
 
 @contextmanager
@@ -61,6 +62,7 @@ def main():
             next_phantom_ip,
             previous_phantom_ip,
             phantom_username,
+            PHANTOM_REST_USERNAME,
             PHANTOM_PASSWORD,
         )
 

--- a/.github/utils/compile_app.py
+++ b/.github/utils/compile_app.py
@@ -135,7 +135,8 @@ def run_compile(
     current_phantom_ip: str,
     next_phantom_ip: str,
     previous_phantom_ip: str,
-    phantom_username: str,
+    ssh_username: str,
+    rest_username: str,
     phantom_password: str,
 ) -> dict[str, dict[str, Union[bool, str]]]:
     results = {}
@@ -149,7 +150,7 @@ def run_compile(
         if not is_local_app_compatible(
             local_app_path,
             host,
-            phantom_username,
+            rest_username,
             phantom_password,
         ):
             message = (
@@ -165,7 +166,7 @@ def run_compile(
         try:
             logging.info(f"Connecting to host {version}: {host}")
             client.connect(
-                hostname=host, username=phantom_username, password=phantom_password, port=22
+                hostname=host, username=ssh_username, password=phantom_password, port=22
             )
             with upload_app_files(version, client, local_app_path, app_name) as test_dir:
                 results[version] = compile_app(version, client, test_dir)

--- a/.github/utils/test_compile_app.py
+++ b/.github/utils/test_compile_app.py
@@ -53,10 +53,14 @@ class CompileAppVersionCompatibilityTest(unittest.TestCase):
             "next.example",
             "previous.example",
             "phantom",
+            "soar_local_admin",
             "password",
         )
 
         ssh_client.assert_not_called()
+        self.assertEqual(_is_compatible.call_count, 3)
+        for call in _is_compatible.call_args_list:
+            self.assertEqual(call.args[2:], ("soar_local_admin", "password"))
         self.assertEqual(
             set(results),
             {


### PR DESCRIPTION
Written and opened by Codex.

PAPP: [PAPP-38037](https://splunk.atlassian.net/browse/PAPP-38037)
Blocked connector: [Zoom PR #36](https://github.com/splunk-soar-connectors/zoom/pull/36)

## Root cause

The traditional compile utility reused its `phantom` SSH username for the HTTP Basic-auth `/rest/version` compatibility probe. These are different identities on the compile instances: direct verification returns HTTP 401 for `phantom` and HTTP 200 for the established SOAR REST user `soar_local_admin` on the current, next, and previous instances.

The password is now correctly available after PR #403, but using it with the SSH identity still triggered the fail-open path and attempted an incompatible 8.6-minimum connector on SOAR 8.4.

## Changes

- Pass separate SSH and REST usernames through the traditional compile utility.
- Keep `phantom` for SSH file upload and compilation.
- Use `soar_local_admin` for the existing HTTP Basic-auth version probe, matching the SDK compile path.
- Extend the focused test to verify all compatibility checks receive the REST identity.

## Validation

- Direct `/rest/version` checks on all three compile instances: `phantom` returned 401; `soar_local_admin` returned 200.
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.github uv run --no-config --default-index https://pypi.org/simple --with backoff --with paramiko --with scp --with requests --with packaging python -m unittest -v utils.test_compile_action utils.test_compile_app` — 5 tests passed.
- Changed-file pre-commit hooks passed.
- `git diff --check` passed.
