### PR TITLE
fix: retry transient SDK app install failures

### DIFF
--- a/.github/actions/compile-app/action.yml
+++ b/.github/actions/compile-app/action.yml
@@ -44,11 +44,27 @@ runs:
         TARBALL_ABS_PATH=$(readlink -f "$TARBALL")
         echo "Tarball created: $TARBALL_NAME"
 
+        install_sdk_app() {
+          local instance="$1"
+          local attempt
+          for attempt in 1 2 3; do
+            if uv run soarapps package install "$TARBALL_NAME" "$instance" --username soar_local_admin; then
+              return 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "SDKfied app installation failed on $instance after $attempt attempts"
+              return 1
+            fi
+            echo "SDKfied app installation failed on $instance (attempt $attempt/3); retrying in $((attempt * 15)) seconds"
+            sleep $((attempt * 15))
+          done
+        }
+
         echo "Checking version compatibility for current phantom instance (${{ inputs.current_phantom_ip }})"
         COMPATIBLE=$(python ${{ github.action_path }}/../../utils/version_compat.py "$TARBALL_ABS_PATH" "${{ inputs.current_phantom_ip }}" soar_local_admin "$PHANTOM_PASSWORD")
         if [ "$COMPATIBLE" == "true" ]; then
           echo "Installing app on current phantom instance (${{ inputs.current_phantom_ip }})"
-          uv run soarapps package install "$TARBALL_NAME" "${{ inputs.current_phantom_ip }}" --username soar_local_admin
+          install_sdk_app "${{ inputs.current_phantom_ip }}"
         else
           echo "Skipping install on current phantom instance (${{ inputs.current_phantom_ip }}): app's min_phantom_version is not supported by this instance"
         fi
@@ -57,7 +73,7 @@ runs:
         COMPATIBLE=$(python ${{ github.action_path }}/../../utils/version_compat.py "$TARBALL_ABS_PATH" "${{ inputs.next_phantom_ip }}" soar_local_admin "$PHANTOM_PASSWORD")
         if [ "$COMPATIBLE" == "true" ]; then
           echo "Installing app on next phantom instance (${{ inputs.next_phantom_ip }})"
-          uv run soarapps package install "$TARBALL_NAME" "${{ inputs.next_phantom_ip }}" --username soar_local_admin
+          install_sdk_app "${{ inputs.next_phantom_ip }}"
         else
           echo "Skipping install on next phantom instance (${{ inputs.next_phantom_ip }}): app's min_phantom_version is not supported by this instance"
         fi
@@ -66,7 +82,7 @@ runs:
         COMPATIBLE=$(python ${{ github.action_path }}/../../utils/version_compat.py "$TARBALL_ABS_PATH" "${{ inputs.previous_phantom_ip }}" soar_local_admin "$PHANTOM_PASSWORD")
         if [ "$COMPATIBLE" == "true" ]; then
           echo "Installing app on previous phantom instance (${{ inputs.previous_phantom_ip }})"
-          uv run soarapps package install "$TARBALL_NAME" "${{ inputs.previous_phantom_ip }}" --username soar_local_admin
+          install_sdk_app "${{ inputs.previous_phantom_ip }}"
         else
           echo "Skipping install on previous phantom instance (${{ inputs.previous_phantom_ip }}): app's min_phantom_version is not supported by this instance"
         fi

--- a/.github/utils/test_compile_action.py
+++ b/.github/utils/test_compile_action.py
@@ -3,11 +3,23 @@ from pathlib import Path
 
 
 class CompileActionTest(unittest.TestCase):
-    def test_traditional_compile_receives_phantom_password(self):
+    def setUp(self):
         action_path = Path(__file__).parents[1] / "actions" / "compile-app" / "action.yml"
-        traditional_step = action_path.read_text().split("- name: Compile Traditional App", 1)[1]
+        self.action = action_path.read_text()
+
+    def test_traditional_compile_receives_phantom_password(self):
+        traditional_step = self.action.split("- name: Compile Traditional App", 1)[1]
 
         self.assertIn("PHANTOM_PASSWORD: ${{ inputs.phantom_password }}", traditional_step)
+
+    def test_sdk_installs_retry_transient_failures(self):
+        sdk_step = self.action.split("- name: Build and Install SDKfied App", 1)[1].split(
+            "- name: Compile Traditional App", 1
+        )[0]
+
+        self.assertIn("install_sdk_app()", sdk_step)
+        self.assertIn("for attempt in 1 2 3", sdk_step)
+        self.assertEqual(sdk_step.count('install_sdk_app "${{ inputs.'), 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Written by Codex.

## Summary

SDKfied connector compilation currently installs each built app once. A transient SOAR upload timeout therefore fails the mandatory compile gate even when the app built successfully and other target instances accepted it.

This change retries each SDK app installation up to three times with short bounded backoff, while preserving a hard failure after the final attempt.

## Motivation

Google Workspace for Gmail PR #67 hit the same `soarapps package install` `ReadTimeout` twice against the shared next-version instance after current-version installation succeeded. This is shared-infrastructure friction and belongs in the platform workflow rather than individual connector code.

## Tracking

- [PAPP-37990](https://splunk.atlassian.net/browse/PAPP-37990)
- Connector reference: https://github.com/splunk-soar-connectors/googleworkspaceforgmail/pull/67

## Verification

- compile action unit tests: 2 passed
- changed-file pre-commit hooks: passed
- YAML validation: passed

Prepared entirely with AI assistance by Codex.
