### PR TITLE
fix: prewarm pre-commit hook wheels

### DIFF
--- a/.github/actions/pre-commit/action.yml
+++ b/.github/actions/pre-commit/action.yml
@@ -4,18 +4,61 @@ runs:
   using: "composite"
   steps:
 
+    - name: Restore pre-commit environments
+      id: pre-commit-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit-env-v1-${{ runner.os }}-${{ runner.arch }}-py3.13-${{ hashFiles('.pre-commit-config.yaml') }}
+
     - name: Install dependencies
       shell: bash
       run: |
         pip install --upgrade pip pre-commit
         pre-commit install
 
+    - name: Select hook wheels
+      id: hook-wheels
+      shell: bash
+      run: |
+        python "${{ github.action_path }}/../../utils/prewarm_precommit_wheels.py" \
+          --github-output "$GITHUB_OUTPUT"
+
+    - name: Prepare hook wheelhouse
+      shell: bash
+      run: mkdir -p "${{ runner.temp }}/pre-commit-wheelhouse"
+
+    - name: Restore hook wheelhouse
+      id: hook-wheelhouse
+      if: steps.hook-wheels.outputs.enabled == 'true'
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ runner.temp }}/pre-commit-wheelhouse
+        key: pre-commit-wheelhouse-v1-${{ runner.os }}-${{ runner.arch }}-py3.13-${{ steps.hook-wheels.outputs.digest }}
+
+    - name: Prewarm hook wheels
+      if: steps.hook-wheels.outputs.enabled == 'true' && steps.hook-wheelhouse.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        python "${{ github.action_path }}/../../utils/prewarm_precommit_wheels.py" \
+          --wheelhouse "${{ runner.temp }}/pre-commit-wheelhouse"
+
+    - name: Save hook wheelhouse
+      if: steps.hook-wheels.outputs.enabled == 'true' && steps.hook-wheelhouse.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ runner.temp }}/pre-commit-wheelhouse
+        key: pre-commit-wheelhouse-v1-${{ runner.os }}-${{ runner.arch }}-py3.13-${{ steps.hook-wheels.outputs.digest }}
+
     - name: Run pre-commit
       shell: bash
+      env:
+        PIP_FIND_LINKS: ${{ runner.temp }}/pre-commit-wheelhouse
       run: pre-commit run --all-files --show-diff-on-failure
 
-    - name: Cache pre-commit
-      uses: actions/cache@v4
+    - name: Save pre-commit environments
+      if: steps.pre-commit-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
       with:
         path: ~/.cache/pre-commit
-        key: ${{ runner.os }}-pre-commit-cache
+        key: pre-commit-env-v1-${{ runner.os }}-${{ runner.arch }}-py3.13-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/utils/prewarm_precommit_wheels.py
+++ b/.github/utils/prewarm_precommit_wheels.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Prepare verified wheels required by supported pre-commit hooks."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from pre_commit.clientlib import load_config
+
+
+HOOK_PACKAGES = {
+    "https://github.com/astral-sh/ruff-pre-commit": "ruff",
+    "https://github.com/charliermarsh/ruff-pre-commit": "ruff",
+    "https://github.com/returntocorp/semgrep": "semgrep",
+}
+VERSION_RE = re.compile(r"\d+(?:\.\d+)+(?:[._+-][A-Za-z0-9.]+)?$")
+
+
+def wheel_specs(config_path: Path) -> list[str]:
+    specs: set[str] = set()
+    for repo in load_config(config_path)["repos"]:
+        package = HOOK_PACKAGES.get(str(repo.get("repo", "")).removesuffix(".git"))
+        if package is None:
+            continue
+        version = str(repo.get("rev", "")).removeprefix("v")
+        if not VERSION_RE.fullmatch(version):
+            raise ValueError(f"Unsupported {package} hook revision: {version!r}")
+        specs.add(f"{package}=={version}")
+        if package == "semgrep":
+            for hook in repo.get("hooks", []):
+                for dependency in hook.get("additional_dependencies", []):
+                    if str(dependency).startswith("setuptools"):
+                        specs.add(str(dependency))
+    return sorted(specs)
+
+
+def write_outputs(specs: list[str], output_path: Path) -> None:
+    digest = hashlib.sha256("\n".join(specs).encode()).hexdigest()
+    with output_path.open("a", encoding="utf-8") as output:
+        output.write(f"enabled={'true' if specs else 'false'}\n")
+        output.write(f"digest={digest}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=Path, default=Path(".pre-commit-config.yaml"))
+    parser.add_argument("--wheelhouse", type=Path)
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args()
+
+    specs = wheel_specs(args.config)
+    if args.github_output:
+        write_outputs(specs, args.github_output)
+    if args.wheelhouse and specs:
+        args.wheelhouse.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "download",
+                "--only-binary=:all:",
+                "--dest",
+                str(args.wheelhouse),
+                *specs,
+            ],
+            check=True,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/utils/test_prewarm_precommit_wheels.py
+++ b/.github/utils/test_prewarm_precommit_wheels.py
@@ -1,0 +1,58 @@
+"""Tests for pre-commit wheel selection."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest import TestCase, main
+from unittest.mock import patch
+
+
+MODULE_PATH = Path(__file__).with_name("prewarm_precommit_wheels.py")
+SPEC = importlib.util.spec_from_file_location("prewarm_precommit_wheels", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class WheelSpecsTests(TestCase):
+    def test_selects_supported_hook_wheels(self) -> None:
+        config = {
+            "repos": [
+                {"repo": "https://github.com/astral-sh/ruff-pre-commit", "rev": "v0.15.22"},
+                {"repo": "https://github.com/charliermarsh/ruff-pre-commit", "rev": "v0.11.2"},
+                {
+                    "repo": "https://github.com/returntocorp/semgrep.git",
+                    "rev": "1.165.0",
+                    "hooks": [
+                        {"additional_dependencies": ["setuptools==81.0.0", "typing-extensions"]}
+                    ],
+                },
+            ]
+        }
+        with patch.object(MODULE, "load_config", return_value=config):
+            self.assertEqual(
+                MODULE.wheel_specs(Path("ignored")),
+                [
+                    "ruff==0.11.2",
+                    "ruff==0.15.22",
+                    "semgrep==1.165.0",
+                    "setuptools==81.0.0",
+                ],
+            )
+
+    def test_rejects_non_version_hook_revisions(self) -> None:
+        config = {
+            "repos": [{"repo": "https://github.com/astral-sh/ruff-pre-commit", "rev": "main"}]
+        }
+        with patch.object(MODULE, "load_config", return_value=config):
+            with self.assertRaisesRegex(ValueError, "Unsupported ruff hook revision"):
+                MODULE.wheel_specs(Path("ignored"))
+
+    def test_ignores_unrelated_hooks(self) -> None:
+        with patch.object(MODULE, "load_config", return_value={"repos": []}):
+            self.assertEqual(MODULE.wheel_specs(Path("ignored")), [])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Bug Fixes

- Restores pre-commit environments before the gate and saves them with a runner/config-specific key.
- Derives allowlisted Ruff and Semgrep wheel requirements from each connector configuration, prewarms a reusable wheelhouse, and supplies it to hook initialization.
- Supports both the legacy `charliermarsh` and current `astral-sh` Ruff hook repositories.

### Manual Documentation

- [x] No manual documentation change is needed; this only changes shared CI behavior.

### Other information

This addresses intermittent empty wheel downloads during fresh pre-commit environments without changing connector source or pinning transitive dependencies below their compatible resolution.

Validation:
- `python -m py_compile` for the helper and its tests
- helper unit tests
- helper execution against this repository's current pre-commit config
- focused pre-commit run on the changed files
- YAML parsing and `git diff --check`

Written by Codex.