### PR TITLE
fix: preserve app imports in SDK pytest

### DIFF
--- a/.github/actions/metrics/send_metrics.py
+++ b/.github/actions/metrics/send_metrics.py
@@ -17,7 +17,9 @@ from utils.api.gitlab import GitLabApi
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("app_json_path", help="Path to the JSON file in the Git repository")
-    parser.add_argument("old_app_json_path", help="Path to file containing app json before the merge")
+    parser.add_argument(
+        "old_app_json_path", help="Path to file containing app json before the merge"
+    )
     parser.add_argument(
         "-t", "--timeout", type=int, default=1200, help="Max time in seconds to wait for completion"
     )

--- a/.github/actions/pr-labeling/action.yml
+++ b/.github/actions/pr-labeling/action.yml
@@ -25,7 +25,7 @@ runs:
       shell: bash
       run: |
         pip install requests PyGithub gitpython
-    
+
     - name: Run PR labeling
       shell: bash
       env:

--- a/.github/actions/pr-labeling/assign_pr_labels.py
+++ b/.github/actions/pr-labeling/assign_pr_labels.py
@@ -44,24 +44,22 @@ def create_jira_ticket(jira_user, jira_api_key, app_name, is_certified, pr_info)
     if not jira_user or not jira_api_key:
         logging.warning("JIRA credentials not provided, skipping ticket creation")
         return None
-    
+
     ticket_summary = JIRA_SUMMARY_TEMPLATE.format(
         app_name, CERTIFIED_LABEL.capitalize() if is_certified else NOT_CERTIFIED_LABEL.capitalize()
     )
 
     logging.info("Creating Jira ticket for %s", pr_info.html_url)
-    
+
     # Use basic auth with username and API key
     auth = (jira_user, jira_api_key)
-    
-    headers = {
-        "Content-Type": "application/json"
-    }
-    
+
+    headers = {"Content-Type": "application/json"}
+
     labels = [f"appname-{app_name}", EXTERNAL_CONTRIBUTOR_LABEL]
     if not is_certified:
         labels.append(NOT_CERTIFIED_LABEL)
-    
+
     payload = {
         "fields": {
             "project": {"key": JIRA_PROJECT_KEY},
@@ -78,17 +76,13 @@ def create_jira_ticket(jira_user, jira_api_key, app_name, is_certified, pr_info)
             "labels": labels,
         }
     }
-    
+
     try:
         response = requests.post(
-            f"{JIRA_URL}/rest/api/2/issue",
-            headers=headers,
-            json=payload,
-            auth=auth,
-            timeout=30
+            f"{JIRA_URL}/rest/api/2/issue", headers=headers, json=payload, auth=auth, timeout=30
         )
         response.raise_for_status()
-        
+
         result = response.json()
         logging.info("Response from Jira: %s", result)
         return result["key"]
@@ -101,16 +95,18 @@ def check_if_internal_contributor(github_client, repo_name, user):
     """Check if user is internal by checking repository collaborator status"""
     try:
         repo = github_client.get_repo(repo_name)
-        
+
         # Check if user is a collaborator on the repository
         try:
             permission = repo.get_collaborator_permission(user)
-            logging.info("User %s has '%s' permission on repository %s", user, permission, repo_name)
+            logging.info(
+                "User %s has '%s' permission on repository %s", user, permission, repo_name
+            )
             return permission in GITHUB_ROLES_WITH_WRITE_PERMISSION
         except Exception:
             logging.info("User %s is not a direct collaborator on repository %s", user, repo_name)
             return False
-            
+
     except Exception as e:
         logging.warning("Could not check collaborator status: %s", str(e))
         return False
@@ -120,7 +116,6 @@ def find_app_json_name(json_filenames):
     """Return most likely app json"""
     filtered_json_filenames = []
     for fname in json_filenames:
-
         # Ignore the postman collection JSON files
         if "postman_collection" in fname.lower():
             continue
@@ -142,27 +137,27 @@ def find_app_json_name(json_filenames):
 def get_app_json_from_repo(github_client, repo_name, pr_number):
     """Attempt to read the app JSON from the app's repository"""
     repo = github_client.get_repo(repo_name)
-    
+
     # First try the default branch
     try:
         default_branch = repo.default_branch
         contents = repo.get_contents("", ref=default_branch)
         json_files = [item.name for item in contents if item.name.endswith(".json")]
         app_json_name = find_app_json_name(json_files)
-        
+
         app_json_contents = repo.get_contents(app_json_name, ref=default_branch)
-        return json.loads(app_json_contents.decoded_content.decode('utf-8'))
+        return json.loads(app_json_contents.decoded_content.decode("utf-8"))
     except Exception:
         logging.info("Could not find app JSON in default branch of %s", repo_name)
-    
+
     try:
         pr = repo.get_pull(pr_number)
         contents = repo.get_contents("", ref=pr.head.sha)
         json_files = [item.name for item in contents if item.name.endswith(".json")]
         app_json_name = find_app_json_name(json_files)
-        
+
         app_json_contents = repo.get_contents(app_json_name, ref=pr.head.sha)
-        return json.loads(app_json_contents.decoded_content.decode('utf-8'))
+        return json.loads(app_json_contents.decoded_content.decode("utf-8"))
     except Exception:
         logging.info("Could not find app JSON in PR head branch for %s", repo_name)
         return None
@@ -171,81 +166,85 @@ def get_app_json_from_repo(github_client, repo_name, pr_number):
 def post_acknowledging_comment(github_client, repo_name, pr_number):
     """Post an acknowledging comment for external contributors"""
     repo = github_client.get_repo(repo_name)
-    
+
     # Search for open PRs with external-contributor label
     query = f"is:pr is:open repo:{repo_name} label:{EXTERNAL_CONTRIBUTOR_LABEL}"
     open_prs = list(github_client.search_issues(query))
-    
+
     if open_prs:
         comment = ACK_COMMENT_OTHER_PRS_OPEN.format(len(open_prs))
     else:
         comment = ACK_COMMENT_NO_PRS_OPEN
-    
+
     pr = repo.get_pull(pr_number)
     pr.create_issue_comment(comment)
 
 
 def assign_pr_labels():
     """Main function to assign PR labels"""
-    github_token = os.getenv('GITHUB_TOKEN')
-    jira_user = os.getenv('JIRA_USER')
-    jira_api_key = os.getenv('JIRA_API_KEY')
-    repo_name = os.getenv('REPO_NAME')
-    pr_number = int(os.getenv('PR_NUMBER'))
-    
+    github_token = os.getenv("GITHUB_TOKEN")
+    jira_user = os.getenv("JIRA_USER")
+    jira_api_key = os.getenv("JIRA_API_KEY")
+    repo_name = os.getenv("REPO_NAME")
+    pr_number = int(os.getenv("PR_NUMBER"))
+
     if not all([github_token, repo_name, pr_number]):
-        raise ValueError("Missing required environment variables: GITHUB_TOKEN, REPO_NAME, or PR_NUMBER")
-    
+        raise ValueError(
+            "Missing required environment variables: GITHUB_TOKEN, REPO_NAME, or PR_NUMBER"
+        )
+
     github_client = Github(github_token)
     repo = github_client.get_repo(repo_name)
     pr = repo.get_pull(pr_number)
-    
+
     user = pr.user.login
-    
+
     # Check if user is external contributor
     is_internal = check_if_internal_contributor(github_client, repo_name, user)
     is_external_contributor = not is_internal
-    
-    logging.info("User %s is %s contributor", 
-                user, "external" if is_external_contributor else "internal")
-    
-    
+
+    logging.info(
+        "User %s is %s contributor", user, "external" if is_external_contributor else "internal"
+    )
+
     labels_to_add = []
     existing_labels = {label.name for label in pr.labels}
-    
+
     if is_external_contributor:
         labels_to_add.append(EXTERNAL_CONTRIBUTOR_LABEL)
-        logging.info("Adding label %s for external contributor %s", EXTERNAL_CONTRIBUTOR_LABEL, user)
-        
+        logging.info(
+            "Adding label %s for external contributor %s", EXTERNAL_CONTRIBUTOR_LABEL, user
+        )
+
         # All external contributors get an acknowledgment comment
         post_acknowledging_comment(github_client, repo_name, pr_number)
-    
+
     try:
         app_json = get_app_json_from_repo(github_client, repo_name, pr_number)
         if app_json:
             is_certified = app_json.get("publisher") == "Splunk"
-            
+
             # Add certification label if not already present
-            if (CERTIFIED_LABEL not in existing_labels and 
-                NOT_CERTIFIED_LABEL not in existing_labels):
+            if (
+                CERTIFIED_LABEL not in existing_labels
+                and NOT_CERTIFIED_LABEL not in existing_labels
+            ):
                 labels_to_add.append(CERTIFIED_LABEL if is_certified else NOT_CERTIFIED_LABEL)
                 logging.info(f"Adding label {labels_to_add[-1]} for app {repo_name}")
-            
+
             # Create JIRA ticket for external contributors
-            if (is_external_contributor and 
-                not any(JIRA_LABEL_PATTERN.match(lb) for lb in existing_labels)):
-                
+            if is_external_contributor and not any(
+                JIRA_LABEL_PATTERN.match(lb) for lb in existing_labels
+            ):
                 jira_ticket = create_jira_ticket(
-                    jira_user, jira_api_key, 
-                    repo_name.split('/')[-1],
-                    is_certified, pr
+                    jira_user, jira_api_key, repo_name.split("/")[-1], is_certified, pr
                 )
                 if jira_ticket:
                     labels_to_add.append(jira_ticket)
                     logging.info("Adding new JIRA ticket label %s", jira_ticket)
     except Exception as e:
         raise RuntimeError(f"Error when processing app JSON: {e}") from e
-    
+
     # Apply labels
     if labels_to_add:
         current_labels = [label.name for label in pr.labels]

--- a/.github/actions/sdkfied-app-setup/action.yml
+++ b/.github/actions/sdkfied-app-setup/action.yml
@@ -13,7 +13,7 @@ runs:
         curl -LsSf https://astral.sh/uv/install.sh | sh
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       shell: bash
-    
+
     - name: Setup UV Environment
       run: |
         cd "${{ inputs.uv_lock_directory }}"
@@ -21,4 +21,3 @@ runs:
         uv sync
         echo "UV environment setup completed successfully"
       shell: bash
-

--- a/.github/utils/compile_app.py
+++ b/.github/utils/compile_app.py
@@ -165,9 +165,7 @@ def run_compile(
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         try:
             logging.info(f"Connecting to host {version}: {host}")
-            client.connect(
-                hostname=host, username=ssh_username, password=phantom_password, port=22
-            )
+            client.connect(hostname=host, username=ssh_username, password=phantom_password, port=22)
             with upload_app_files(version, client, local_app_path, app_name) as test_dir:
                 results[version] = compile_app(version, client, test_dir)
         finally:

--- a/.github/utils/update_version.py
+++ b/.github/utils/update_version.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from typing import Optional
 import tomlkit
 
+
 def find_app_json_name(json_filenames: list[str]) -> str:
     """
     Given a list of possible json files and the app repo name, return the name of the file
@@ -36,7 +37,6 @@ def find_app_json_name(json_filenames: list[str]) -> str:
 
     # There's only one json file in the top level, so it must be the app's json
     return filtered_json_filenames[0]
-
 
 
 def update_app_version_in_app_json(app_json_name: str, new_version: str) -> None:
@@ -69,7 +69,7 @@ def update_app_version_in_toml(toml_path: Path, new_version: str) -> None:
     print(f"Updating {toml_path} with new version: {new_version}")
     with open(toml_path) as f:
         toml_data = tomlkit.load(f)
-    
+
     toml_data["project"]["version"] = new_version
     with open(toml_path, "w") as f:
         tomlkit.dump(toml_data, f)
@@ -128,9 +128,15 @@ def create_cmdline_parser() -> argparse.ArgumentParser:
     argparser.add_argument(
         "new_version", type=str, help="The new version the app json will be updated to"
     )
-    argparser.add_argument("release_notes", type=str, nargs='?', help="The release notes for the new version (optional, can also be passed via RELEASE_NOTES env var)")
+    argparser.add_argument(
+        "release_notes",
+        type=str,
+        nargs="?",
+        help="The release notes for the new version (optional, can also be passed via RELEASE_NOTES env var)",
+    )
 
     return argparser
+
 
 def find_uv_lock_file(connector_path: Path) -> Optional[Path]:
     """
@@ -141,6 +147,7 @@ def find_uv_lock_file(connector_path: Path) -> Optional[Path]:
     for uv_lock_path in connector_path.rglob("uv.lock"):
         return uv_lock_path
 
+
 def main(**kwargs):
     if not kwargs.get("new_version") or not re.match(r"^\d+\.\d+\.\d+$", kwargs.get("new_version")):
         print(
@@ -149,16 +156,15 @@ def main(**kwargs):
         exit(1)
 
     new_version = kwargs.get("new_version")
-    
-    # Get release notes from argument or environment variable (env var fixes arg passing issues)
-    release_notes = kwargs.get("release_notes") or os.environ.get("RELEASE_NOTES", "")
 
     # Look for the app json file in the current directory
     if uv_lock_file := find_uv_lock_file(Path(os.getcwd())):
         pyproject_toml_path = uv_lock_file.parent / "pyproject.toml"
         update_app_version_in_toml(pyproject_toml_path, new_version)
     else:
-        app_json_name = find_app_json_name([f for f in os.listdir(os.getcwd()) if f.endswith(".json")])
+        app_json_name = find_app_json_name(
+            [f for f in os.listdir(os.getcwd()) if f.endswith(".json")]
+        )
         print(f"Found one top-level json file: {app_json_name}")
         update_app_version_in_app_json(app_json_name, new_version)
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -82,7 +82,7 @@ jobs:
           uv_lock_directory: ${{ env.UV_LOCK_DIRECTORY }}
 
       - name: Run pytest
-        run: uv run --project "$UV_LOCK_DIRECTORY" pytest
+        run: uv run --project "$UV_LOCK_DIRECTORY" python -m pytest
 
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changed

Run SDK connector tests with `uv run python -m pytest` instead of invoking the `pytest` console script directly.

## Why

The console-script invocation does not reliably retain the connector checkout on `sys.path`, so SDK apps whose tests import the generated `src` package fail during collection with `ModuleNotFoundError: No module named 'src'`. Microsoft 365 PR 10 reproduces this across all five test modules; the identical suite passes 17/17 through `python -m pytest`.

This belongs in the shared workflow rather than a connector-local import-path workaround.

## Tracking

- [PAPP-37973](https://splunk.atlassian.net/browse/PAPP-37973)
- [Microsoft 365 PR 10](https://github.com/splunk-soar-connectors/microsoft365/pull/10)
- Parent epic: [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228)

## Verification

- `pre-commit run --all-files` — passed
- Microsoft 365: `uv run python -m pytest` — 17 passed
- Microsoft 365: `uv run pytest` — reproduces the five `src` import collection failures

The repository-wide gate also exposed a pre-existing unused assignment and required mechanical formatting updates. Those are isolated in a separate cleanup commit so the full configured pre-commit suite now passes.

Written by Codex.
