### PR TITLE
ESPM-5228: fix: isolate compile staging directories

### DIFF
--- a/.github/utils/compile_app.py
+++ b/.github/utils/compile_app.py
@@ -1,14 +1,12 @@
 import json
 import logging
-import os
-import random
 import re
 import socket
-import string
 from contextlib import contextmanager
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Union
+import shlex
 
 import backoff
 import paramiko
@@ -20,19 +18,21 @@ from utils.version_compat import supports_minimum_version
 ANSI_ESCAPE = re.compile(r"(\x1b|\x1B)(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 OUTPUT = re.compile(r"Output\:([^\x1b]*?)Error output\:")
 
-TEST_APP_DIRECTORY_TEMPLATE = "/home/phantom/app_tests/{app_name}"
-TEST_DIRECTORY = "/home/phantom/app_tests"
-RANDOM_STRING = "/{}/".format(
-    "".join(random.choices(string.ascii_uppercase + string.ascii_lowercase, k=7))
-)
+COMPILE_STAGING_DIRECTORY = Path("/home/phantom/.soar-compile")
+STAGING_DIRECTORY_PREFIX = "compile-"
+
+
+def get_app_json_name(local_app_path: Path) -> str:
+    local_app_path = Path(local_app_path)
+    json_filenames = [path.name for path in local_app_path.glob("*.json")]
+    return (
+        "manifest.json" if "manifest.json" in json_filenames else find_app_json_name(json_filenames)
+    )
 
 
 def get_min_phantom_version(local_app_path: Path) -> str:
     local_app_path = Path(local_app_path)
-    json_filenames = [path.name for path in local_app_path.glob("*.json")]
-    app_json_name = (
-        "manifest.json" if "manifest.json" in json_filenames else find_app_json_name(json_filenames)
-    )
+    app_json_name = get_app_json_name(local_app_path)
 
     with (local_app_path / app_json_name).open() as app_json_file:
         return json.load(app_json_file)["min_phantom_version"]
@@ -95,37 +95,89 @@ def compile_app(
     return response
 
 
-def make_folder(
-    phantom_version: str, phantom_client: paramiko.SSHClient, app_name: str, test_directory: Path
-) -> None:
-    commands = f"mkdir -p {test_directory}; cd {test_directory}"
-    logging.info(commands)
-    logging.info(f"Creating folder for {app_name} on phantom {phantom_version}")
-    phantom_client.exec_command(commands)
+def run_remote_command(phantom_client: paramiko.SSHClient, command: str, description: str) -> str:
+    """Run a remote command and fail closed when setup or verification fails."""
+    logging.info(command)
+    _, stdout, stderr = phantom_client.exec_command(command)
+    exit_code = int(stdout.channel.recv_exit_status())
+    output = "".join(stdout.readlines()).strip()
+    if exit_code != 0:
+        error = "".join(stderr.readlines()).strip()
+        raise RuntimeError(f"{description} failed with exit code {exit_code}: {error}")
+    return output
+
+
+def is_owned_staging_directory(test_directory: Path) -> bool:
+    """Return whether the requested cleanup path is one created by this helper."""
+    test_directory = Path(test_directory)
+    return test_directory.parent == COMPILE_STAGING_DIRECTORY and test_directory.name.startswith(
+        STAGING_DIRECTORY_PREFIX
+    )
+
+
+def create_staging_directory(phantom_version: str, phantom_client: paramiko.SSHClient) -> Path:
+    staging_template = COMPILE_STAGING_DIRECTORY / f"{STAGING_DIRECTORY_PREFIX}XXXXXXXX"
+    command = (
+        "set -e; umask 077; "
+        f"mkdir -p {shlex.quote(str(COMPILE_STAGING_DIRECTORY))}; "
+        f"mktemp -d {shlex.quote(str(staging_template))}"
+    )
+    logging.info("Creating isolated compile directory on phantom %s", phantom_version)
+    staging_directory = Path(
+        run_remote_command(phantom_client, command, "create compile staging directory")
+    )
+    if not is_owned_staging_directory(staging_directory):
+        raise RuntimeError(
+            f"Remote mktemp returned an unexpected compile directory: {staging_directory}"
+        )
+    return staging_directory
 
 
 def delete_folder(phantom_client: paramiko.SSHClient, test_directory: Path) -> None:
-    commands = f"rm -rf {test_directory}"
-    logging.info("Deleting folder %s", test_directory)
-    logging.info(commands)
-    if " " not in test_directory and TEST_DIRECTORY in TEST_APP_DIRECTORY_TEMPLATE:
-        phantom_client.exec_command(commands)
+    """Remove only an isolated staging directory that this helper owns."""
+    test_directory = Path(test_directory)
+    if not is_owned_staging_directory(test_directory):
+        logging.warning("Refusing to remove unowned compile directory: %s", test_directory)
+        return
+
+    command = f"rm -rf -- {shlex.quote(str(test_directory))}"
+    logging.info("Deleting isolated compile directory %s", test_directory)
+    run_remote_command(phantom_client, command, "remove compile staging directory")
 
 
 @contextmanager
 def upload_app_files(
-    phantom_version: str, phantom_client: paramiko.SSHClient, local_app_path: Path, app_name: str
+    phantom_version: str, phantom_client: paramiko.SSHClient, local_app_path: Path, _app_name: str
 ) -> Iterator[Path]:
-    remote_path = TEST_APP_DIRECTORY_TEMPLATE.format(app_name=app_name + RANDOM_STRING)
-    make_folder(phantom_version, phantom_client, app_name, remote_path)
+    staging_directory = create_staging_directory(phantom_version, phantom_client)
+    incoming_directory = staging_directory / ".incoming"
+    uploaded_app_directory = incoming_directory / local_app_path.name
+    test_directory = staging_directory / "app"
+    manifest_filename = get_app_json_name(local_app_path)
 
-    logging.info(f"Uploading files on {phantom_version}")
-    with SCPClient(phantom_client.get_transport()) as scp:
-        scp.put(local_app_path, recursive=True, remote_path=remote_path)
+    try:
+        run_remote_command(
+            phantom_client,
+            f"mkdir {shlex.quote(str(incoming_directory))}",
+            "create incoming compile directory",
+        )
+        logging.info("Uploading files on %s", phantom_version)
+        with SCPClient(phantom_client.get_transport()) as scp:
+            scp.put(local_app_path, recursive=True, remote_path=str(incoming_directory))
 
-    yield os.path.join(remote_path, os.path.basename(local_app_path))
-
-    delete_folder(phantom_client, remote_path)
+        promote_command = (
+            "set -e; "
+            f"test -d {shlex.quote(str(uploaded_app_directory))}; "
+            f"mv {shlex.quote(str(uploaded_app_directory))} {shlex.quote(str(test_directory))}; "
+            f"test -d {shlex.quote(str(test_directory))}; "
+            f"test -f {shlex.quote(str(test_directory / manifest_filename))}"
+        )
+        run_remote_command(
+            phantom_client, promote_command, "promote and verify uploaded compile directory"
+        )
+        yield test_directory
+    finally:
+        delete_folder(phantom_client, staging_directory)
 
 
 @backoff.on_exception(backoff.expo, socket.error, max_tries=3)

--- a/.github/utils/test_compile_app.py
+++ b/.github/utils/test_compile_app.py
@@ -72,5 +72,82 @@ class CompileAppVersionCompatibilityTest(unittest.TestCase):
         self.assertTrue(all(result["success"] for result in results.values()))
 
 
+class CompileAppStagingTest(unittest.TestCase):
+    def test_accepts_only_owned_staging_directories_for_cleanup(self):
+        owned_directory = compile_app.COMPILE_STAGING_DIRECTORY / "compile-ABC12345"
+
+        self.assertTrue(compile_app.is_owned_staging_directory(owned_directory))
+        self.assertFalse(compile_app.is_owned_staging_directory(Path("/tmp/compile-ABC12345")))
+        self.assertFalse(
+            compile_app.is_owned_staging_directory(
+                compile_app.COMPILE_STAGING_DIRECTORY / "not-a-compile-directory"
+            )
+        )
+
+    @mock.patch.object(compile_app, "run_remote_command")
+    def test_deletes_only_owned_staging_directory(self, run_remote_command):
+        owned_directory = compile_app.COMPILE_STAGING_DIRECTORY / "compile-ABC12345"
+
+        compile_app.delete_folder(mock.Mock(), owned_directory)
+        compile_app.delete_folder(mock.Mock(), Path("/tmp/compile-ABC12345"))
+
+        run_remote_command.assert_called_once()
+        command = run_remote_command.call_args.args[1]
+        self.assertEqual(command, f"rm -rf -- {owned_directory}")
+
+    @mock.patch.object(
+        compile_app,
+        "run_remote_command",
+        return_value="/home/phantom/.soar-compile/compile-ABC12345",
+    )
+    def test_creates_mktemp_staging_directory(self, run_remote_command):
+        staging_directory = compile_app.create_staging_directory("previous", mock.Mock())
+
+        self.assertEqual(
+            staging_directory, compile_app.COMPILE_STAGING_DIRECTORY / "compile-ABC12345"
+        )
+        command = run_remote_command.call_args.args[1]
+        self.assertIn("mktemp -d", command)
+        self.assertIn("/home/phantom/.soar-compile/compile-XXXXXXXX", command)
+
+    @mock.patch.object(compile_app, "delete_folder")
+    @mock.patch.object(compile_app, "run_remote_command")
+    @mock.patch.object(
+        compile_app,
+        "create_staging_directory",
+        return_value=Path("/home/phantom/.soar-compile/compile-ABC12345"),
+    )
+    @mock.patch.object(compile_app, "SCPClient")
+    def test_upload_promotes_and_verifies_before_compile(
+        self, scp_client, _create_staging_directory, run_remote_command, delete_folder
+    ):
+        with tempfile.TemporaryDirectory() as temp_directory:
+            app_path = Path(temp_directory) / "example"
+            app_path.mkdir()
+            (app_path / "example.json").write_text(json.dumps({"min_phantom_version": "8.6.0"}))
+            phantom_client = mock.Mock()
+
+            with compile_app.upload_app_files(
+                "previous", phantom_client, app_path, "example"
+            ) as test_dir:
+                self.assertEqual(test_dir, Path("/home/phantom/.soar-compile/compile-ABC12345/app"))
+
+        scp_client.return_value.__enter__.return_value.put.assert_called_once_with(
+            app_path,
+            recursive=True,
+            remote_path="/home/phantom/.soar-compile/compile-ABC12345/.incoming",
+        )
+        self.assertEqual(run_remote_command.call_count, 2)
+        promote_command = run_remote_command.call_args_list[1].args[1]
+        self.assertIn("mv", promote_command)
+        self.assertIn("test -d /home/phantom/.soar-compile/compile-ABC12345/app", promote_command)
+        self.assertIn(
+            "test -f /home/phantom/.soar-compile/compile-ABC12345/app/example.json", promote_command
+        )
+        delete_folder.assert_called_once_with(
+            phantom_client, Path("/home/phantom/.soar-compile/compile-ABC12345")
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Written by Codex.

- Move traditional-app compile staging from the shared `/home/phantom/app_tests` tree to a per-host, per-attempt `mktemp` directory under `/home/phantom/.soar-compile`.
- Upload into `.incoming`, atomically promote the complete app directory, and require both the staged directory and selected manifest before invoking `phenv compile_app -i`.
- Delete only the exact owned staging root, with containment checked against the actual requested path.

## Evidence

RSA Security Analytics PR #25 and vSphere PR #30 each uploaded successfully, then only SOAR 8.4 lost the shared staging directory before compilation. The central helper's prior cleanup occurred only after compile returned; vSphere passed on retry with a fresh path.

## Verification

- `pre-commit run --all-files`
- `PYTHONPATH=.github uv run --with backoff --with paramiko --with scp --with packaging python .github/utils/test_compile_app.py`
- `python -m compileall -q .github/utils/compile_app.py .github/utils/test_compile_app.py`
- `git diff --check`

## Scope

No connector code or SOAR authentication behavior changed.