### PR TITLE
fix: skip packaging connector template

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,6 +120,8 @@ jobs:
         shell: bash
 
   build:
+    # connector-template intentionally uses a sentinel app ID and is not a publishable app.
+    if: github.event.repository.name != 'connector-template'
     runs-on: ubuntu-latest
     needs: [semantic-version, detect-app-type]
     env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -224,7 +224,7 @@ jobs:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
       - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
     needs: publish
-    if: always()
+    if: always() && needs.publish.result != 'skipped'
     steps:
     - name: Check out app repo
       uses: actions/checkout@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -199,6 +199,8 @@ jobs:
           uv_lock_directory: ${{ needs.detect-app-type.outputs.uv_lock_directory }}
 
   build:
+    # connector-template intentionally uses a sentinel app ID and is not a publishable app.
+    if: github.event.repository.name != 'connector-template'
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
       - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231


### PR DESCRIPTION
## Summary

- skip app packaging for the connector-template repository in pull request workflows
- skip the same non-publishable template in release publishing workflows
- retain compile and pre-commit coverage for template changes

## Why

connector-template intentionally uses the sentinel app ID ffffffff-ffff-4fff-afff-ffffffffffff because it is scaffolding, not a publishable app. The shared builder correctly rejects that ID for real apps, so the workflow should not attempt to package this repository.

This unblocks splunk-soar-connectors/connector-template#10 and PAPP-38137 without weakening app ID validation.

## Verification

- pre-commit run --all-files
- YAML validation
- Docker-backed ShellCheck

Merge strategy: merge commit only; do not squash.

This PR was created entirely with AI assistance. Written by Codex.