### PR TITLE
fix: accept string paths in compile staging

### DIFF
--- a/.github/utils/compile_app.py
+++ b/.github/utils/compile_app.py
@@ -147,8 +147,12 @@ def delete_folder(phantom_client: paramiko.SSHClient, test_directory: Path) -> N
 
 @contextmanager
 def upload_app_files(
-    phantom_version: str, phantom_client: paramiko.SSHClient, local_app_path: Path, _app_name: str
+    phantom_version: str,
+    phantom_client: paramiko.SSHClient,
+    local_app_path: Union[Path, str],
+    _app_name: str,
 ) -> Iterator[Path]:
+    local_app_path = Path(local_app_path)
     staging_directory = create_staging_directory(phantom_version, phantom_client)
     incoming_directory = staging_directory / ".incoming"
     uploaded_app_directory = incoming_directory / local_app_path.name

--- a/.github/utils/test_compile_app.py
+++ b/.github/utils/test_compile_app.py
@@ -128,7 +128,7 @@ class CompileAppStagingTest(unittest.TestCase):
             phantom_client = mock.Mock()
 
             with compile_app.upload_app_files(
-                "previous", phantom_client, app_path, "example"
+                "previous", phantom_client, str(app_path), "example"
             ) as test_dir:
                 self.assertEqual(test_dir, Path("/home/phantom/.soar-compile/compile-ABC12345/app"))
 


### PR DESCRIPTION
## Summary

- normalize local checkout paths at the compile upload boundary
- cover the GitPython `working_tree_dir` string used by the live action

## Root cause

[PR #413](https://github.com/splunk-soar-connectors/.github/pull/413) added isolated compile staging and accessed `local_app_path.name`, but the action caller supplies a string. Converting the value to `Path` at the boundary preserves the isolated staging behavior and restores connector compilation.

## Validation

- `PYTHONPATH=.github uv run --with backoff --with paramiko --with scp --with requests python -m unittest utils.test_compile_app` — 8 passed
- `pre-commit run --all-files` — passed

Prepared entirely with AI assistance by Codex.
