### PR TITLE
feat: serialize Splunkbase publishing per user

### DIFF
--- a/.github/SPLUNKBASE_PUBLISH_QUEUE.md
+++ b/.github/SPLUNKBASE_PUBLISH_QUEUE.md
@@ -1,0 +1,80 @@
+# Splunkbase publish queue
+
+This runbook and the queue implementation were written by Codex.
+
+Splunkbase permits 20 upload attempts per hour for each publishing user, and every
+multipart upload attempt counts. Connector builds remain parallel, but this queue
+serializes the upload POSTs made by the shared SOAR connector user.
+
+## Safety properties
+
+The worker starts at most one upload every five minutes and no more than 12 uploads
+during the preceding hour. It records a slot before making the POST. A worker restart
+therefore cannot reset the budget. Read-only Splunkbase requests retain bounded retries,
+but multipart upload POSTs have no automatic retries.
+
+Queue items are GitHub issues in this repository. Artifacts are uniquely named assets on
+the `splunkbase-publish-queue` prerelease. Both contain only public connector and
+operational metadata; credentials remain in GitHub Actions secrets. The deduplication
+key is publishing-user alias, repository, and connector version.
+
+## Configuration
+
+Before enabling the queue, configure these Actions secrets on
+`splunk-soar-connectors/.github`:
+
+- `SPLUNKBASE_USER`
+- `SPLUNKBASE_PASSWORD`
+- `SLACK_INTERNAL_TOKEN`
+- `SLACK_COMMUNITY_TOKEN`
+
+Confirm the existing channel variables are available:
+
+- `SLACK_INTERNAL_CHANNEL_ID`
+- `SLACK_COMMUNITY_CHANNEL_ID`
+- `SEND_RELEASE_MESSAGE`
+
+The enqueue job uses the existing `SEMANTIC_RELEASE_APP_ID` organization variable and
+the `SEMANTIC_RELEASE_PK` secret already passed by connector caller workflows. The App
+needs `contents:write` on `splunk-soar-connectors/.github`; it does not need issue,
+Actions, check, or status permissions.
+
+Keep `SPLUNKBASE_PUBLISH_QUEUE_ENABLED` unset or `false` while configuring and testing.
+The reusable workflow continues to publish directly in that state, with one upload POST
+per job. Set this variable to `true` for only the five approved canary repositories
+first. After the canary passes, expose the same variable to all connector repositories
+and this central repository.
+
+## Canary
+
+Enqueue five approved connector versions together. Verify:
+
+1. Five open issues appear with `splunkbase-publish` and `splunkbase-queued`.
+2. The state issue records no starts less than five minutes apart.
+3. Each successful issue closes with `splunkbase-published`.
+4. Metrics and Slack notifications run only after the worker confirms publication.
+5. Splunkbase logs show the stable `Splunk-SOAR-Connector-Publisher/1.0` User-Agent plus
+   repository, version, source run, and source attempt fields.
+
+Do not canary CrowdSec until its publishing-user invitation is accepted. Do not use
+Microsoft OneDrive v2 as a canary.
+
+## Recovery
+
+An active item carries a 15-minute lease. If a worker dies, the item becomes eligible
+again after the lease. The next worker checks whether the version exists before
+reserving another upload slot.
+
+HTTP 429 requeues the item after `Retry-After` plus 30 seconds and makes no second POST.
+HTTP 401 or 403 and definitive validation failures leave the issue open with
+`splunkbase-blocked`. An ambiguous timeout, reset, or server error triggers GET-only
+reconciliation; it is requeued only when the candidate version is still absent.
+
+To retry a corrected blocked item, preserve its JSON body, replace
+`splunkbase-blocked` with `splunkbase-queued`, and set `not_before` to the current UTC
+time. Do not rerun a POST manually under the same user while the queue is enabled,
+because manual attempts are invisible to the persisted budget.
+
+To disable the queue, set `SPLUNKBASE_PUBLISH_QUEUE_ENABLED` to `false`. Wait for any
+active worker to finish before using direct publication. Do not operate both paths
+simultaneously under the same Splunkbase user.

--- a/.github/SPLUNKBASE_PUBLISH_QUEUE.md
+++ b/.github/SPLUNKBASE_PUBLISH_QUEUE.md
@@ -20,19 +20,28 @@ key is publishing-user alias, repository, and connector version.
 
 ## Configuration
 
-Before enabling the queue, configure these Actions secrets on
-`splunk-soar-connectors/.github`:
+After this change merges, open
+`splunk-soar-connectors/.github` → **Settings** → **Secrets and variables** →
+**Actions**.
 
-- `SPLUNKBASE_USER`
-- `SPLUNKBASE_PASSWORD`
+Under **Secrets**, add these repository secrets, or grant this repository access to the
+existing organization secrets with the same names:
+
+- `SPLUNKBASE_USER`: the shared connector publishing username
+- `SPLUNKBASE_PASSWORD`: the shared connector publishing password
+
+Slack configuration is optional. If release notifications must remain enabled, also
+make these secrets available to this repository:
+
 - `SLACK_INTERNAL_TOKEN`
 - `SLACK_COMMUNITY_TOKEN`
 
-Confirm the existing channel variables are available:
+Under **Variables**, make the existing channel configuration available when Slack
+notifications are enabled:
 
 - `SLACK_INTERNAL_CHANNEL_ID`
 - `SLACK_COMMUNITY_CHANNEL_ID`
-- `SEND_RELEASE_MESSAGE`
+- `SEND_RELEASE_MESSAGE=true`
 
 The enqueue job reuses the GitHub App `splunk-soar-semantic-release` (App ID `1190653`).
 Connector workflows supply its ID through the existing `SEMANTIC_RELEASE_APP_ID`
@@ -44,11 +53,23 @@ permissions. No GitHub App permission change is required for this queue. The cen
 workflow uses its repository-scoped `GITHUB_TOKEN`, with `issues:write` declared in the
 workflow, to create and update queue issues.
 
-Keep `SPLUNKBASE_PUBLISH_QUEUE_ENABLED` unset or `false` while configuring and testing.
-The reusable workflow continues to publish directly in that state, with one upload POST
-per job. Set this variable to `true` for only the five approved canary repositories
-first. After the canary passes, expose the same variable to all connector repositories
-and this central repository.
+Keep `SPLUNKBASE_PUBLISH_QUEUE_ENABLED` unset or `false` while configuring. The reusable
+workflow continues to publish directly in that state, with one upload POST per job.
+
+For the canary:
+
+1. In each of the five approved connector repositories, open **Settings** →
+   **Secrets and variables** → **Actions** → **Variables** and add
+   `SPLUNKBASE_PUBLISH_QUEUE_ENABLED=true`.
+2. In `splunk-soar-connectors/.github`, add the same repository variable with value
+   `true`. This enables the scheduled central worker.
+3. After the canary passes, make `SPLUNKBASE_PUBLISH_QUEUE_ENABLED=true` available to
+   all connector repositories, preferably as one organization variable, while keeping
+   it available to this central repository.
+
+No other repository setting needs to change. Issues and Actions are already enabled,
+the required actions are already allowlisted, and the repository's `GITHUB_TOKEN`
+already has read/write workflow permissions.
 
 ## Canary
 

--- a/.github/SPLUNKBASE_PUBLISH_QUEUE.md
+++ b/.github/SPLUNKBASE_PUBLISH_QUEUE.md
@@ -88,8 +88,10 @@ Microsoft OneDrive v2 as a canary.
 ## Recovery
 
 An active item carries a 15-minute lease. If a worker dies, the item becomes eligible
-again after the lease. The next worker checks whether the version exists before
-reserving another upload slot.
+again after the lease. If a counted attempt was started, the next worker treats the
+outcome as ambiguous and performs GET-only reconciliation; it does not reserve another
+slot or issue another POST. The app-existence snapshot is persisted before the publisher
+runs so a newly created app can still receive its editors during recovery.
 
 HTTP 429 requeues the item after `Retry-After` plus 30 seconds and makes no second POST.
 HTTP 401 or 403 and definitive validation failures leave the issue open with
@@ -104,8 +106,11 @@ and fails the worker job.
 
 To retry a corrected blocked item, preserve its JSON body, replace
 `splunkbase-blocked` with `splunkbase-queued`, and set `not_before` to the current UTC
-time. Do not rerun a POST manually under the same user while the queue is enabled,
-because manual attempts are invisible to the persisted budget.
+time. To explicitly retry an interrupted attempt whose result never became durable,
+replace `splunkbase-verifying` with `splunkbase-queued`, clear `verification`, and change
+its latest attempt `outcome` from `started` to `retry_authorized`. Do not rerun a POST
+manually under the same user while the queue is enabled, because manual attempts are
+invisible to the persisted budget.
 
 To disable the queue, set `SPLUNKBASE_PUBLISH_QUEUE_ENABLED` to `false`. Wait for any
 active worker to finish before using direct publication. Do not operate both paths

--- a/.github/SPLUNKBASE_PUBLISH_QUEUE.md
+++ b/.github/SPLUNKBASE_PUBLISH_QUEUE.md
@@ -93,8 +93,14 @@ reserving another upload slot.
 
 HTTP 429 requeues the item after `Retry-After` plus 30 seconds and makes no second POST.
 HTTP 401 or 403 and definitive validation failures leave the issue open with
-`splunkbase-blocked`. An ambiguous timeout, reset, or server error triggers GET-only
-reconciliation; it is requeued only when the candidate version is still absent.
+`splunkbase-blocked`. Once Splunkbase accepts a POST, the worker immediately persists
+the package and request IDs and moves any inconclusive status check to
+`splunkbase-verifying`. Verification workers use only release-list and package-status
+GETs; they neither reserve another upload slot nor send another multipart POST.
+Continued validation, timeouts, exhausted server-error retries, and unreadable
+responses remain in verification. The issue closes when the version appears or the
+package validates, while a definitive rejection transitions to `splunkbase-blocked`
+and fails the worker job.
 
 To retry a corrected blocked item, preserve its JSON body, replace
 `splunkbase-blocked` with `splunkbase-queued`, and set `not_before` to the current UTC

--- a/.github/SPLUNKBASE_PUBLISH_QUEUE.md
+++ b/.github/SPLUNKBASE_PUBLISH_QUEUE.md
@@ -34,10 +34,13 @@ Confirm the existing channel variables are available:
 - `SLACK_COMMUNITY_CHANNEL_ID`
 - `SEND_RELEASE_MESSAGE`
 
-The enqueue job uses the existing `SEMANTIC_RELEASE_APP_ID` organization variable and
-the `SEMANTIC_RELEASE_PK` secret already passed by connector caller workflows. The App
-needs `contents:write` on `splunk-soar-connectors/.github`; it does not need issue,
-Actions, check, or status permissions.
+The enqueue job reuses the GitHub App `splunk-soar-semantic-release` (App ID `1190653`).
+Connector workflows supply its ID through the existing `SEMANTIC_RELEASE_APP_ID`
+organization variable and pass its private key through `SEMANTIC_RELEASE_PK`. This App
+has `contents:write`, `metadata:read`, and `pull_requests:write` across the connector
+organization. The queue uses only `contents:write` on
+`splunk-soar-connectors/.github`; it does not need issue, Actions, check, or status
+permissions.
 
 Keep `SPLUNKBASE_PUBLISH_QUEUE_ENABLED` unset or `false` while configuring and testing.
 The reusable workflow continues to publish directly in that state, with one upload POST

--- a/.github/SPLUNKBASE_PUBLISH_QUEUE.md
+++ b/.github/SPLUNKBASE_PUBLISH_QUEUE.md
@@ -40,7 +40,9 @@ organization variable and pass its private key through `SEMANTIC_RELEASE_PK`. Th
 has `contents:write`, `metadata:read`, and `pull_requests:write` across the connector
 organization. The queue uses only `contents:write` on
 `splunk-soar-connectors/.github`; it does not need issue, Actions, check, or status
-permissions.
+permissions. No GitHub App permission change is required for this queue. The central
+workflow uses its repository-scoped `GITHUB_TOKEN`, with `issues:write` declared in the
+workflow, to create and update queue issues.
 
 Keep `SPLUNKBASE_PUBLISH_QUEUE_ENABLED` unset or `false` while configuring and testing.
 The reusable workflow continues to publish directly in that state, with one upload POST

--- a/.github/actions/enqueue-publish/action.yml
+++ b/.github/actions/enqueue-publish/action.yml
@@ -1,0 +1,88 @@
+name: "Enqueue Splunkbase publish"
+description: "Stores an immutable connector artifact and enqueues one serialized upload."
+inputs:
+  artifact_path:
+    description: "Path to the connector .tgz artifact."
+    required: true
+  github_token:
+    description: "GitHub App token with contents:write on the central queue repository."
+    required: true
+  commit_sha:
+    description: "Immutable connector release commit represented by the artifact."
+    required: true
+  queue_repository:
+    description: "Repository that owns the central Splunkbase queue."
+    required: false
+    default: "splunk-soar-connectors/.github"
+  publisher_alias:
+    description: "Stable non-secret name for the shared Splunkbase identity."
+    required: false
+    default: "soar-connectors-default"
+  release_tag:
+    description: "Prerelease used as durable queue artifact storage."
+    required: false
+    default: "splunkbase-publish-queue"
+outputs:
+  candidate_version:
+    description: "Connector version placed in the queue."
+    value: ${{ steps.prepare.outputs.candidate_version }}
+  dedupe_key:
+    description: "Per-user, repository, and version idempotency key."
+    value: ${{ steps.prepare.outputs.dedupe_key }}
+runs:
+  using: "composite"
+  steps:
+    - name: Prepare queue metadata
+      id: prepare
+      shell: bash
+      run: |
+        python "${{ github.action_path }}/prepare_enqueue.py" \
+          --artifact "${{ inputs.artifact_path }}" \
+          --repository "${{ github.repository }}" \
+          --commit-sha "${{ inputs.commit_sha }}" \
+          --run-id "${{ github.run_id }}" \
+          --run-attempt "${{ github.run_attempt }}" \
+          --publisher-alias "${{ inputs.publisher_alias }}" \
+          --release-tag "${{ inputs.release_tag }}" \
+          --payload-path "${RUNNER_TEMP}/splunkbase-enqueue.json"
+
+    - name: Ensure durable queue release exists
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        QUEUE_REPOSITORY: ${{ inputs.queue_repository }}
+        RELEASE_TAG: ${{ inputs.release_tag }}
+      run: |
+        if ! gh release view "$RELEASE_TAG" --repo "$QUEUE_REPOSITORY" >/dev/null 2>&1; then
+          if ! gh release create "$RELEASE_TAG" \
+              --repo "$QUEUE_REPOSITORY" \
+              --prerelease \
+              --title "Splunkbase publish queue" \
+              --notes "Operational artifact storage managed by Codex-authored automation."; then
+            gh release view "$RELEASE_TAG" --repo "$QUEUE_REPOSITORY" >/dev/null
+          fi
+        fi
+        gh release view "$RELEASE_TAG" --repo "$QUEUE_REPOSITORY" >/dev/null
+
+    - name: Store immutable connector artifact
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        QUEUE_REPOSITORY: ${{ inputs.queue_repository }}
+        RELEASE_TAG: ${{ inputs.release_tag }}
+        ASSET_NAME: ${{ steps.prepare.outputs.asset_name }}
+      run: |
+        cp "${{ inputs.artifact_path }}" "${RUNNER_TEMP}/$ASSET_NAME"
+        gh release upload "$RELEASE_TAG" "${RUNNER_TEMP}/$ASSET_NAME" \
+          --repo "$QUEUE_REPOSITORY" \
+          --clobber
+
+    - name: Enqueue central publication
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        QUEUE_REPOSITORY: ${{ inputs.queue_repository }}
+      run: |
+        gh api "repos/$QUEUE_REPOSITORY/dispatches" \
+          --method POST \
+          --input "${RUNNER_TEMP}/splunkbase-enqueue.json"

--- a/.github/actions/enqueue-publish/prepare_enqueue.py
+++ b/.github/actions/enqueue-publish/prepare_enqueue.py
@@ -1,0 +1,90 @@
+"""Prepare immutable Splunkbase queue metadata from a connector package."""
+
+import argparse
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import re
+import tarfile
+
+
+def get_app_json(tarball: Path) -> dict:
+    with tarfile.open(tarball, "r:*") as archive:
+        matches = [
+            name
+            for name in archive.getnames()
+            if name.endswith(".json")
+            and name.count("/") == 1
+            and "postman_collection" not in name.lower()
+        ]
+        if len(matches) != 1:
+            raise ValueError(f"Expected one top-level app JSON, found: {matches}")
+        app_file = archive.extractfile(matches[0])
+        if app_file is None:
+            raise ValueError(f"Could not read {matches[0]} from {tarball}")
+        return json.load(app_file)
+
+
+def safe_asset_part(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-")
+
+
+def write_output(name: str, value: str) -> None:
+    output_path = os.getenv("GITHUB_OUTPUT")
+    if output_path:
+        with open(output_path, "a") as output:
+            output.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--artifact", type=Path, required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--commit-sha", required=True)
+    parser.add_argument("--run-id", type=int, required=True)
+    parser.add_argument("--run-attempt", type=int, required=True)
+    parser.add_argument("--publisher-alias", required=True)
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--payload-path", type=Path, required=True)
+    args = parser.parse_args()
+
+    app_json = get_app_json(args.artifact)
+    version = str(app_json["app_version"])
+    asset_name = (
+        f"{safe_asset_part(args.publisher_alias)}--"
+        f"{safe_asset_part(args.repository)}--"
+        f"{safe_asset_part(version)}--"
+        f"{safe_asset_part(args.commit_sha[:12])}.tgz"
+    )
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    payload = {
+        "event_type": "splunkbase-publish-enqueue",
+        "client_payload": {
+            "schema_version": 1,
+            "publisher_alias": args.publisher_alias,
+            "repository": args.repository,
+            "run_id": args.run_id,
+            "run_attempt": args.run_attempt,
+            "commit_sha": args.commit_sha,
+            "artifact_name": "app-tar",
+            "asset_name": asset_name,
+            "release_tag": args.release_tag,
+            "candidate_version": version,
+            "appid": str(app_json["appid"]),
+            "app_name": str(app_json["name"]),
+            "enqueued_at": now,
+            "not_before": now,
+        },
+    }
+    args.payload_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+    write_output("asset_name", asset_name)
+    write_output("candidate_version", version)
+    write_output("appid", str(app_json["appid"]))
+    write_output("dedupe_key", f"{args.publisher_alias}:{args.repository}:{version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/actions/enqueue-publish/test_prepare_enqueue.py
+++ b/.github/actions/enqueue-publish/test_prepare_enqueue.py
@@ -1,0 +1,31 @@
+import importlib.util
+import io
+import json
+from pathlib import Path
+import tarfile
+
+
+MODULE_PATH = Path(__file__).with_name("prepare_enqueue.py")
+SPEC = importlib.util.spec_from_file_location("prepare_enqueue", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_app_metadata_and_asset_name_are_stable(tmp_path):
+    tarball = tmp_path / "connector.tgz"
+    manifest = json.dumps(
+        {
+            "appid": "example-guid",
+            "app_version": "2.3.4",
+            "name": "Example",
+        }
+    ).encode()
+    info = tarfile.TarInfo("example/example.json")
+    info.size = len(manifest)
+    with tarfile.open(tarball, "w:gz") as archive:
+        archive.addfile(info, io.BytesIO(manifest))
+
+    assert MODULE.get_app_json(tarball)["app_version"] == "2.3.4"
+    assert (
+        MODULE.safe_asset_part("splunk-soar-connectors/example") == "splunk-soar-connectors-example"
+    )

--- a/.github/actions/metrics/action.yml
+++ b/.github/actions/metrics/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "What the return code was from the publish action was"
     required: true
     default: 0
+  repo_path:
+    description: "Connector checkout containing the current and previous app manifests."
+    required: false
+    default: "."
 runs:
   using: 'composite'
   steps:
@@ -21,6 +25,7 @@ runs:
     - name: Send metrics
       shell: bash
       run: |
+        cd "${{ inputs.repo_path }}"
         APP_JSON=$(find "$(pwd)" -maxdepth 1 -name '*.json' ! -name '*.postman_collection.json')
         APP_JSON_NAME=$(find . -maxdepth 1 -name '*.json' ! -name '*.postman_collection.json')
 

--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -25,6 +25,10 @@ inputs:
   splunk_base_url:
     description: "URL to the app on Splunkbase"
     required: true
+  workspace_path:
+    description: "Connector checkout containing the app logo."
+    required: false
+    default: "."
   slack_internal_token:
     description: "Slack bot token for the internal channel"
     required: true
@@ -58,6 +62,7 @@ runs:
         NEW_APP: ${{ inputs.new_app }}
         SUPPORT_TAG: ${{ inputs.support_tag }}
         SPLUNK_BASE_URL: ${{ inputs.splunk_base_url }}
+        GITHUB_WORKSPACE: ${{ inputs.workspace_path }}
         SLACK_INTERNAL_TOKEN: ${{ inputs.slack_internal_token }}
         SLACK_COMMUNITY_TOKEN: ${{ inputs.slack_community_token }}
         SLACK_INTERNAL_CHANNEL: ${{ inputs.slack_internal_channel }}

--- a/.github/actions/publish/requirements.txt
+++ b/.github/actions/publish/requirements.txt
@@ -1,3 +1,5 @@
+backoff>=2.2.1,<3.0.0
 boto3==1.36.2
 gitpython==3.1.44
+packaging>=24.2,<26.0
 requests>=2.32.3,<3.0.0

--- a/.github/actions/publish/test_upload_to_splunkbase.py
+++ b/.github/actions/publish/test_upload_to_splunkbase.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import tarfile
 
 from packaging.version import parse
+import pytest
+import requests
 
 
 MODULE_PATH = Path(__file__).with_name("upload_to_splunkbase.py")
@@ -56,4 +58,152 @@ def test_structured_rate_limit_result_is_written(tmp_path, monkeypatch):
         "retry_after": "300",
         "status": "rate_limited",
         "status_code": 429,
+    }
+
+
+@pytest.mark.parametrize(
+    "validation_error",
+    [
+        requests.Timeout("validation timed out"),
+        requests.ConnectionError("validation connection failed"),
+        RuntimeError("validation GET exhausted 5xx retries"),
+        ValueError("validation response was not JSON"),
+    ],
+)
+def test_post_upload_get_failure_stays_in_verification(validation_error):
+    client = type(
+        "Client",
+        (),
+        {"check_upload_status": lambda self, package_id: (_ for _ in ()).throw(validation_error)},
+    )()
+
+    status, response = MODULE._check_post_upload_validation(client, "package-123")
+
+    assert status == "verifying"
+    assert response == {}
+
+
+def test_continued_validation_stays_in_verification():
+    response = {"message": "Package validation still in progress."}
+    client = type(
+        "Client",
+        (),
+        {
+            "check_upload_status": lambda self, package_id: response,
+            "_is_retryable_response": lambda self, value: True,
+        },
+    )()
+
+    assert MODULE._check_post_upload_validation(client, "package-123") == (
+        "verifying",
+        response,
+    )
+
+
+def test_definitive_validation_rejection_is_classified():
+    response = {"message": "Package failed validation.", "errors": ["invalid manifest"]}
+    client = type(
+        "Client",
+        (),
+        {
+            "check_upload_status": lambda self, package_id: response,
+            "_is_retryable_response": lambda self, value: False,
+        },
+    )()
+
+    assert MODULE._check_post_upload_validation(client, "package-123") == (
+        "validation_failed",
+        response,
+    )
+
+
+@pytest.mark.parametrize("response", [{}, {"message": "unknown"}, ["malformed"]])
+def test_inconclusive_validation_response_stays_in_verification(response):
+    client = type(
+        "Client",
+        (),
+        {
+            "check_upload_status": lambda self, package_id: response,
+            "_is_retryable_response": lambda self, value: False,
+        },
+    )()
+
+    status, _ = MODULE._check_post_upload_validation(client, "package-123")
+
+    assert status == "verifying"
+
+
+def test_unexpected_failure_preserves_written_verification_result(tmp_path, monkeypatch):
+    result_path = tmp_path / "publish-result.json"
+    result = {
+        "status": "verifying",
+        "package_id": "package-123",
+        "request_id": "request-123",
+    }
+    result_path.write_text(json.dumps(result))
+    monkeypatch.setattr(MODULE, "PUBLISH_RESULT_PATH", str(result_path))
+    monkeypatch.setattr(MODULE, "parse_args", lambda: object())
+    monkeypatch.setattr(
+        MODULE,
+        "main",
+        lambda args: (_ for _ in ()).throw(RuntimeError("post-upload failure")),
+    )
+
+    assert MODULE.cli() == MODULE.RESULT_CODES["verifying"]
+    assert json.loads(result_path.read_text()) == result
+
+
+def test_accepted_upload_persists_package_metadata_before_failed_status_get(
+    tmp_path,
+    monkeypatch,
+):
+    result_path = tmp_path / "publish-result.json"
+
+    class Client:
+        last_upload_request_id = "request-123"
+        status_checks = 0
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_existing_releases(self, appid):
+            return []
+
+        def get_apps(self, filters):
+            return []
+
+        def upload_app(self, *args):
+            return "package-123"
+
+        def check_upload_status(self, package_id):
+            type(self).status_checks += 1
+            raise requests.Timeout("validation timed out")
+
+    monkeypatch.setattr(MODULE, "PUBLISH_RESULT_PATH", str(result_path))
+    monkeypatch.setenv("UPLOAD_PATH", str(tmp_path / "connector.tgz"))
+    monkeypatch.setattr(
+        MODULE,
+        "get_app_json",
+        lambda tarball: {
+            "appid": "example-guid",
+            "app_version": "1.2.3",
+            "name": "Example",
+            "publisher": "Splunk",
+        },
+    )
+    monkeypatch.setattr(MODULE, "get_release_notes", lambda *args: "* Fixed validation.")
+    monkeypatch.setattr(MODULE, "get_license_info", lambda app_json: ("license", "url"))
+    monkeypatch.setattr(MODULE, "Splunkbase", Client)
+
+    code = MODULE.main(type("Args", (), {"app_repo_name": "example"})())
+
+    assert code == MODULE.RESULT_CODES["verifying"]
+    assert Client.status_checks == 0
+    assert json.loads(result_path.read_text()) == {
+        "appid": "example-guid",
+        "app_name": "Example",
+        "package_id": "package-123",
+        "release_version": "1.2.3",
+        "request_id": "request-123",
+        "status": "verifying",
     }

--- a/.github/actions/publish/test_upload_to_splunkbase.py
+++ b/.github/actions/publish/test_upload_to_splunkbase.py
@@ -14,6 +14,8 @@ SPEC = importlib.util.spec_from_file_location("upload_to_splunkbase", MODULE_PAT
 MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 
+from utils.api.splunkbase import build_user_agent
+
 
 def test_existing_version_is_only_successful_on_rerun():
     version = parse("2.3.4")
@@ -162,9 +164,10 @@ def test_accepted_upload_persists_package_metadata_before_failed_status_get(
     class Client:
         last_upload_request_id = "request-123"
         status_checks = 0
+        request_context = None
 
-        def __init__(self, *args, **kwargs):
-            pass
+        def __init__(self, *args, request_context=None, **kwargs):
+            type(self).request_context = request_context
 
         def get_existing_releases(self, appid):
             return []
@@ -181,6 +184,10 @@ def test_accepted_upload_persists_package_metadata_before_failed_status_get(
 
     monkeypatch.setattr(MODULE, "PUBLISH_RESULT_PATH", str(result_path))
     monkeypatch.setenv("UPLOAD_PATH", str(tmp_path / "connector.tgz"))
+    monkeypatch.setenv("GITHUB_RUN_ID", "worker-run")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "9")
+    monkeypatch.setenv("SOURCE_GITHUB_RUN_ID", "source-run")
+    monkeypatch.setenv("SOURCE_GITHUB_RUN_ATTEMPT", "2")
     monkeypatch.setattr(
         MODULE,
         "get_app_json",
@@ -199,8 +206,19 @@ def test_accepted_upload_persists_package_metadata_before_failed_status_get(
 
     assert code == MODULE.RESULT_CODES["verifying"]
     assert Client.status_checks == 0
+    assert Client.request_context == {
+        "repo": "example",
+        "version": "1.2.3",
+        "run_id": "source-run",
+        "run_attempt": "2",
+    }
+    user_agent = build_user_agent(**Client.request_context)
+    assert "run/source-run" in user_agent
+    assert "attempt/2" in user_agent
+    assert "worker-run" not in user_agent
     assert json.loads(result_path.read_text()) == {
         "appid": "example-guid",
+        "app_existed_before_upload": False,
         "app_name": "Example",
         "package_id": "package-123",
         "release_version": "1.2.3",

--- a/.github/actions/publish/test_upload_to_splunkbase.py
+++ b/.github/actions/publish/test_upload_to_splunkbase.py
@@ -1,5 +1,8 @@
 import importlib.util
+import io
+import json
 from pathlib import Path
+import tarfile
 
 from packaging.version import parse
 
@@ -21,3 +24,36 @@ def test_rerun_does_not_accept_an_older_candidate():
     assert not MODULE.is_successful_rerun_of_existing_version(
         parse("2.3.3"), parse("2.3.4"), run_attempt="2"
     )
+
+
+def test_release_notes_can_be_read_from_queued_tarball(tmp_path):
+    tarball = tmp_path / "connector.tgz"
+    release_notes = b"**Unreleased**\n\n* Fixed upload handling.\n"
+    info = tarfile.TarInfo("connector/release_notes/2.3.4.md")
+    info.size = len(release_notes)
+    with tarfile.open(tarball, "w:gz") as archive:
+        archive.addfile(info, io.BytesIO(release_notes))
+
+    assert MODULE.get_release_notes_from_tarball(tarball, "2.3.4") == ("\n* Fixed upload handling.")
+
+
+def test_structured_rate_limit_result_is_written(tmp_path, monkeypatch):
+    result_path = tmp_path / "publish-result.json"
+    monkeypatch.setattr(MODULE, "PUBLISH_RESULT_PATH", str(result_path))
+    error = MODULE.SplunkbaseRateLimited(
+        "rate limited",
+        status_code=429,
+        retry_after="300",
+        request_id="request-123",
+    )
+
+    code = MODULE._record_upload_error("rate_limited", error)
+
+    assert code == 10
+    assert json.loads(result_path.read_text()) == {
+        "message": "rate limited",
+        "request_id": "request-123",
+        "retry_after": "300",
+        "status": "rate_limited",
+        "status_code": 429,
+    }

--- a/.github/actions/publish/upload_to_splunkbase.py
+++ b/.github/actions/publish/upload_to_splunkbase.py
@@ -22,6 +22,11 @@ from utils.api.splunkbase import (
     SGT_LICENSE_STRING,
     SGT_LICENSE_URL,
     Splunkbase,
+    SplunkbaseAmbiguousUpload,
+    SplunkbasePermissionDenied,
+    SplunkbaseRateLimited,
+    SplunkbaseUploadError,
+    SplunkbaseValidationFailed,
 )
 
 NEW_APP_WARNING_MESSAGE = (
@@ -32,6 +37,18 @@ NEW_APP_WARNING_MESSAGE = (
 
 SPLUNKBASE_USER = os.getenv("SPLUNKBASE_USER")
 SPLUNKBASE_PASSWORD = os.getenv("SPLUNKBASE_PASSWORD")
+PUBLISH_RESULT_PATH = os.getenv("PUBLISH_RESULT_PATH")
+
+RESULT_CODES = {
+    "published": 0,
+    "already_published": 0,
+    "failed": 1,
+    "new_app": 2,
+    "rate_limited": 10,
+    "permission_denied": 11,
+    "ambiguous": 12,
+    "validation_failed": 13,
+}
 
 
 def is_successful_rerun_of_existing_version(candidate_version, latest_release, run_attempt=None):
@@ -61,6 +78,9 @@ def get_release_notes(version: str, workspace_path: Optional[Path] = None) -> Op
     release_notes_file = search_root / "release_notes" / f"{version}.md"
     logging.info(f"Looking for release notes at: {release_notes_file}")
 
+    if not release_notes_file.exists():
+        return None
+
     with open(release_notes_file) as f:
         full_release_notes = f.read()
         release_notes = []
@@ -68,6 +88,29 @@ def get_release_notes(version: str, workspace_path: Optional[Path] = None) -> Op
             if not ("unreleased" in line.lower() and "**" in line):
                 release_notes.append(line)
         return "\n".join(release_notes)
+
+
+def get_release_notes_from_tarball(tarball: Union[str, Path], version: str) -> Optional[str]:
+    with tarfile.open(tarball, "r") as tar:
+        expected_suffix = f"/release_notes/{version}.md"
+        matches = [
+            name
+            for name in tar.getnames()
+            if name == f"release_notes/{version}.md" or name.endswith(expected_suffix)
+        ]
+        if len(matches) != 1:
+            logging.error("Expected one release note file in tarball, found: %s", matches)
+            return None
+
+        release_file = tar.extractfile(matches[0])
+        if release_file is None:
+            return None
+        full_release_notes = release_file.read().decode()
+        return "\n".join(
+            line
+            for line in full_release_notes.splitlines()
+            if not ("unreleased" in line.lower() and "**" in line)
+        )
 
 
 def get_app_json(tarball: Union[str, Path]) -> dict[str, Any]:
@@ -124,6 +167,17 @@ def _write_github_outputs(
     logging.info("Wrote GitHub outputs for %s v%s", app_json["name"], app_json["app_version"])
 
 
+def _write_publish_result(status: str, **details: Any) -> None:
+    if not PUBLISH_RESULT_PATH:
+        return
+
+    result = {
+        "status": status,
+        **{key: value for key, value in details.items() if value is not None},
+    }
+    Path(PUBLISH_RESULT_PATH).write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+
+
 def main(args):
     app_repo_name = args.app_repo_name
 
@@ -134,7 +188,14 @@ def main(args):
     appid = app_json["appid"]
 
     logging.info("Candidate version for release: %s", app_version)
-    sb_client = Splunkbase(SPLUNKBASE_USER, SPLUNKBASE_PASSWORD)
+    sb_client = Splunkbase(
+        SPLUNKBASE_USER,
+        SPLUNKBASE_PASSWORD,
+        request_context={
+            "repo": app_repo_name,
+            "version": app_version,
+        },
+    )
 
     existing_releases = sb_client.get_existing_releases(appid)
     if existing_releases:
@@ -170,6 +231,13 @@ def main(args):
                 sb_appid=apps[0]["id"],
                 support_tag=apps[0]["support"],
             )
+            _write_publish_result(
+                "already_published",
+                appid=appid,
+                app_name=app_json["name"],
+                release_version=app_version,
+                splunkbase_app_id=apps[0]["id"],
+            )
             return 0
 
         if candidate_version <= latest_release:
@@ -188,6 +256,8 @@ def main(args):
     logging.info(f"GITHUB_WORKSPACE from environment: {workspace}")
 
     release_notes = get_release_notes(app_version, workspace_path)
+    if not release_notes:
+        release_notes = get_release_notes_from_tarball(tarball, app_version)
     if not release_notes:
         logging.error("Could not find release notes in tarball for version %s!", app_version)
         return 1
@@ -229,6 +299,14 @@ def main(args):
             sb_appid=sb_appid,
             support_tag=support_tag,
         )
+        _write_publish_result(
+            "new_app",
+            appid=appid,
+            app_name=app_json["name"],
+            package_id=package_id,
+            release_version=app_version,
+            splunkbase_app_id=sb_appid,
+        )
         sb_client.add_app_editor(sb_appid)
         logging.warning(NEW_APP_WARNING_MESSAGE)
         return 2
@@ -241,9 +319,46 @@ def main(args):
         sb_appid=sb_appid,
         support_tag=apps[0]["support"],
     )
+    _write_publish_result(
+        "published",
+        appid=appid,
+        app_name=app_json["name"],
+        package_id=package_id,
+        release_version=app_version,
+        splunkbase_app_id=sb_appid,
+    )
     return 0
+
+
+def _record_upload_error(status: str, exc: SplunkbaseUploadError) -> int:
+    logging.error("%s: %s", status, exc)
+    _write_publish_result(
+        status,
+        message=str(exc),
+        request_id=exc.request_id,
+        retry_after=exc.retry_after,
+        status_code=exc.status_code,
+    )
+    return RESULT_CODES[status]
+
+
+def cli() -> int:
+    try:
+        return main(parse_args())
+    except SplunkbaseRateLimited as exc:
+        return _record_upload_error("rate_limited", exc)
+    except SplunkbasePermissionDenied as exc:
+        return _record_upload_error("permission_denied", exc)
+    except SplunkbaseAmbiguousUpload as exc:
+        return _record_upload_error("ambiguous", exc)
+    except SplunkbaseValidationFailed as exc:
+        return _record_upload_error("validation_failed", exc)
+    except Exception:
+        logging.exception("Unexpected Splunkbase publisher failure")
+        _write_publish_result("failed")
+        return RESULT_CODES["failed"]
 
 
 if __name__ == "__main__":
     logging.getLogger().setLevel(logging.INFO)
-    sys.exit(main(parse_args()))
+    sys.exit(cli())

--- a/.github/actions/publish/upload_to_splunkbase.py
+++ b/.github/actions/publish/upload_to_splunkbase.py
@@ -233,6 +233,8 @@ def main(args):
         request_context={
             "repo": app_repo_name,
             "version": app_version,
+            "run_id": os.getenv("SOURCE_GITHUB_RUN_ID"),
+            "run_attempt": os.getenv("SOURCE_GITHUB_RUN_ATTEMPT"),
         },
     )
 
@@ -307,6 +309,13 @@ def main(args):
     logging.info("Using license info: %s: %s", license_string, license_url)
 
     apps = sb_client.get_apps({"appid": appid})
+    publish_details = {
+        "appid": appid,
+        "app_existed_before_upload": bool(apps),
+        "app_name": app_json["name"],
+        "release_version": app_version,
+    }
+    _write_publish_result("uploading", **publish_details)
     if apps:
         sb_appid = apps[0]["id"]
         logging.info("Found existing app with appid: %s: %s", appid, sb_appid)
@@ -321,13 +330,7 @@ def main(args):
 
     logging.info("Package ID: %s", package_id)
     request_id = getattr(sb_client, "last_upload_request_id", None)
-    publish_details = {
-        "appid": appid,
-        "app_name": app_json["name"],
-        "package_id": package_id,
-        "release_version": app_version,
-        "request_id": request_id,
-    }
+    publish_details.update({"package_id": package_id, "request_id": request_id})
     _write_publish_result("verifying", **publish_details)
     if PUBLISH_RESULT_PATH:
         return RESULT_CODES["verifying"]
@@ -358,7 +361,7 @@ def main(args):
             **publish_details,
             splunkbase_app_id=sb_appid,
         )
-        sb_client.add_app_editor(sb_appid)
+        sb_client.ensure_app_editors(sb_appid)
         logging.warning(NEW_APP_WARNING_MESSAGE)
         return 2
 
@@ -380,8 +383,14 @@ def main(args):
 
 def _record_upload_error(status: str, exc: SplunkbaseUploadError) -> int:
     logging.error("%s: %s", status, exc)
+    context = {
+        key: value
+        for key, value in _existing_publish_result().items()
+        if key not in {"status", "message", "request_id", "retry_after", "status_code"}
+    }
     _write_publish_result(
         status,
+        **context,
         message=str(exc),
         request_id=exc.request_id,
         retry_after=exc.retry_after,

--- a/.github/actions/publish/upload_to_splunkbase.py
+++ b/.github/actions/publish/upload_to_splunkbase.py
@@ -48,6 +48,7 @@ RESULT_CODES = {
     "permission_denied": 11,
     "ambiguous": 12,
     "validation_failed": 13,
+    "verifying": 14,
 }
 
 
@@ -178,6 +179,44 @@ def _write_publish_result(status: str, **details: Any) -> None:
     Path(PUBLISH_RESULT_PATH).write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
 
 
+def _existing_publish_result() -> dict[str, Any]:
+    if not PUBLISH_RESULT_PATH:
+        return {}
+    try:
+        return json.loads(Path(PUBLISH_RESULT_PATH).read_text())
+    except (FileNotFoundError, json.JSONDecodeError, TypeError):
+        return {}
+
+
+def _check_post_upload_validation(sb_client: Splunkbase, package_id: str) -> tuple[str, dict]:
+    """Classify one GET-only validation check without risking another upload."""
+
+    try:
+        response = sb_client.check_upload_status(package_id)
+    except Exception:
+        logging.exception(
+            "Could not confirm package %s after Splunkbase accepted the upload; "
+            "leaving it in verification",
+            package_id,
+        )
+        return "verifying", {}
+
+    if not isinstance(response, dict):
+        logging.error("Package %s returned a malformed validation response", package_id)
+        return "verifying", {}
+    if response.get("details", {}).get("id"):
+        return "published", response
+    if sb_client._is_retryable_response(response):
+        logging.info("Package %s is still being validated: %s", package_id, response)
+        return "verifying", response
+    if Splunkbase.is_definitive_validation_failure(response):
+        return "validation_failed", response
+    logging.error(
+        "Package %s returned an inconclusive validation response: %s", package_id, response
+    )
+    return "verifying", response
+
+
 def main(args):
     app_repo_name = args.app_repo_name
 
@@ -281,13 +320,28 @@ def main(args):
         )
 
     logging.info("Package ID: %s", package_id)
-    response = sb_client.check_upload_status(package_id)
+    request_id = getattr(sb_client, "last_upload_request_id", None)
+    publish_details = {
+        "appid": appid,
+        "app_name": app_json["name"],
+        "package_id": package_id,
+        "release_version": app_version,
+        "request_id": request_id,
+    }
+    _write_publish_result("verifying", **publish_details)
+    if PUBLISH_RESULT_PATH:
+        return RESULT_CODES["verifying"]
+
+    validation_status, response = _check_post_upload_validation(sb_client, package_id)
+    if validation_status == "verifying":
+        return RESULT_CODES["verifying"]
+    if validation_status == "validation_failed":
+        logging.error("Splunkbase definitively rejected package %s: %s", package_id, response)
+        _write_publish_result("validation_failed", **publish_details)
+        return RESULT_CODES["validation_failed"]
+
     sb_appid = response.get("details", {}).get("id")
-    if sb_appid:
-        logging.info("Upload validated successfully: \n%s", json.dumps(response, indent=2))
-    else:
-        logging.info("Failed to validate upload: \n%s", json.dumps(response, indent=2))
-        return 1
+    logging.info("Upload validated successfully: \n%s", json.dumps(response, indent=2))
 
     if not apps:
         support_tag = "splunk" if app_json.get("publisher") == "Splunk" else "developer"
@@ -301,10 +355,7 @@ def main(args):
         )
         _write_publish_result(
             "new_app",
-            appid=appid,
-            app_name=app_json["name"],
-            package_id=package_id,
-            release_version=app_version,
+            **publish_details,
             splunkbase_app_id=sb_appid,
         )
         sb_client.add_app_editor(sb_appid)
@@ -321,10 +372,7 @@ def main(args):
     )
     _write_publish_result(
         "published",
-        appid=appid,
-        app_name=app_json["name"],
-        package_id=package_id,
-        release_version=app_version,
+        **publish_details,
         splunkbase_app_id=sb_appid,
     )
     return 0
@@ -355,6 +403,9 @@ def cli() -> int:
         return _record_upload_error("validation_failed", exc)
     except Exception:
         logging.exception("Unexpected Splunkbase publisher failure")
+        if _existing_publish_result().get("status") == "verifying":
+            logging.error("The upload was already accepted; preserving GET-only verification state")
+            return RESULT_CODES["verifying"]
         _write_publish_result("failed")
         return RESULT_CODES["failed"]
 

--- a/.github/scripts/drain_splunkbase_publish_queue.py
+++ b/.github/scripts/drain_splunkbase_publish_queue.py
@@ -168,6 +168,88 @@ def complete_existing(queue, client, item, args) -> int:
     return 0
 
 
+def defer_verification(queue, item, result, now, reason) -> int:
+    queue.verify(
+        item,
+        result,
+        now + MIN_ATTEMPT_INTERVAL,
+        reason,
+    )
+    write_output("queue_status", "verifying")
+    print(reason)
+    return 0
+
+
+def reconcile_verification(queue, client, item, args, now) -> int:
+    """Reconcile an accepted package using GETs only."""
+
+    result = dict(item.verification or {})
+    package_id = result.get("package_id")
+
+    try:
+        if version_exists(client, item.appid, item.candidate_version):
+            return complete_existing(queue, client, item, args)
+    except Exception:
+        print("The release listing could not be read; checking the accepted package directly.")
+
+    if not package_id:
+        return defer_verification(
+            queue,
+            item,
+            result,
+            now,
+            "An accepted upload has no package ID; waiting for version-only reconciliation.",
+        )
+
+    try:
+        response = client.check_upload_status(package_id)
+    except Exception:
+        return defer_verification(
+            queue,
+            item,
+            result,
+            now,
+            "The accepted package could not be read; GET-only verification will retry.",
+        )
+
+    if not isinstance(response, dict):
+        return defer_verification(
+            queue,
+            item,
+            result,
+            now,
+            "Splunkbase returned a malformed package status; GET-only verification will retry.",
+        )
+
+    splunkbase_app_id = response.get("details", {}).get("id")
+    if splunkbase_app_id:
+        result.update(
+            {
+                "status": "reconciled_published",
+                "splunkbase_app_id": splunkbase_app_id,
+            }
+        )
+        return complete_existing(queue, client, item, args)
+
+    if client._is_retryable_response(response) or not Splunkbase.is_definitive_validation_failure(
+        response
+    ):
+        return defer_verification(
+            queue,
+            item,
+            result,
+            now,
+            "Splunkbase validation is still pending; GET-only verification will retry.",
+        )
+
+    result["status"] = "validation_failed"
+    queue.block(item, result)
+    write_output("publish_return_code", 13)
+    write_output("queue_status", "blocked")
+    print(f"Splunkbase definitively rejected accepted package {package_id}.")
+    return 1
+
+
 def publish_item(args) -> int:
     queue = queue_from_environment()
     item = queue.get_item(args.issue_number)
@@ -182,6 +264,9 @@ def publish_item(args) -> int:
             "run_attempt": item.run_attempt,
         },
     )
+
+    if item.verification:
+        return reconcile_verification(queue, splunkbase, item, args, now)
 
     if version_exists(splunkbase, item.appid, item.candidate_version):
         return complete_existing(queue, splunkbase, item, args)
@@ -212,6 +297,15 @@ def publish_item(args) -> int:
         queue.delete_asset(item)
         write_output("queue_status", "published")
         return 0
+
+    if status == "verifying":
+        return defer_verification(
+            queue,
+            item,
+            result,
+            now,
+            "Splunkbase accepted the upload; GET-only verification will retry.",
+        )
 
     if status == "rate_limited":
         not_before = max(

--- a/.github/scripts/drain_splunkbase_publish_queue.py
+++ b/.github/scripts/drain_splunkbase_publish_queue.py
@@ -118,6 +118,8 @@ def run_publisher(args, item) -> tuple[int, dict]:
             "PUBLISH_RESULT_PATH": str(result_path.resolve()),
             "GITHUB_OUTPUT": str(publisher_output.resolve()),
             "GITHUB_WORKSPACE": str(Path(args.connector_workspace).resolve()),
+            "SOURCE_GITHUB_RUN_ID": str(item.run_id),
+            "SOURCE_GITHUB_RUN_ATTEMPT": str(item.run_attempt),
         }
     )
     completed = subprocess.run(
@@ -135,36 +137,57 @@ def run_publisher(args, item) -> tuple[int, dict]:
     return completed.returncode, result
 
 
-def complete_existing(queue, client, item, args) -> int:
+def finalize_publication(queue, client, item, args, result, now) -> int:
+    """Reconstruct release outputs and side effects before closing a queue item."""
+
     publisher = load_publisher_module()
-    app_json = publisher.get_app_json(args.artifact)
-    release_notes = publisher.get_release_notes(
-        item.candidate_version,
-        Path(args.connector_workspace),
-    ) or publisher.get_release_notes_from_tarball(args.artifact, item.candidate_version)
-    apps = client.get_apps({"appid": item.appid})
-    result = {
-        "status": "already_published",
-        "release_version": item.candidate_version,
-    }
-    if apps:
-        result["splunkbase_app_id"] = apps[0]["id"]
-        write_output("splunk_base_url", f"https://splunkbase.splunk.com/app/{apps[0]['id']}")
-        write_output("support_tag", apps[0]["support"])
-    write_output("app_name", item.app_name)
-    write_output("app_logo", app_json["logo"])
-    write_output("repo_name", item.repository.split("/")[-1])
-    write_output("release_version", item.candidate_version)
-    write_output("release_notes", json.dumps((release_notes or "").split("\n")))
-    write_output("new_app", False)
-    write_output("publish_return_code", 0)
-    write_output("queue_status", "published")
+    try:
+        app_json = publisher.get_app_json(args.artifact)
+        release_notes = publisher.get_release_notes(
+            item.candidate_version,
+            Path(args.connector_workspace),
+        ) or publisher.get_release_notes_from_tarball(args.artifact, item.candidate_version)
+        if not release_notes:
+            raise RuntimeError("Release notes could not be reconstructed")
+
+        apps = client.get_apps({"appid": item.appid})
+        if len(apps) != 1:
+            raise RuntimeError(f"Expected one Splunkbase app for {item.appid}, found {len(apps)}")
+        app = apps[0]
+        new_app = not result.get("app_existed_before_upload", True)
+        if new_app:
+            client.ensure_app_editors(app["id"])
+
+        result.update(
+            {
+                "status": "reconciled_published",
+                "release_version": item.candidate_version,
+                "splunkbase_app_id": app["id"],
+            }
+        )
+        write_output("splunk_base_url", f"https://splunkbase.splunk.com/app/{app['id']}")
+        write_output("support_tag", app["support"])
+        write_output("app_name", item.app_name)
+        write_output("app_logo", app_json["logo"])
+        write_output("repo_name", item.repository.split("/")[-1])
+        write_output("release_version", item.candidate_version)
+        write_output("release_notes", json.dumps(release_notes.split("\n")))
+        write_output("new_app", new_app)
+        write_output("publish_return_code", 2 if new_app else 0)
+    except Exception as exc:
+        return defer_verification(
+            queue,
+            item,
+            result,
+            now,
+            f"Publication is visible but finalization failed ({type(exc).__name__}); "
+            "GET-only recovery will retry.",
+        )
+
     queue.complete(item, result)
     queue.delete_asset(item)
-    print(
-        f"{item.repository} v{item.candidate_version} already exists; "
-        "no upload attempt was consumed."
-    )
+    write_output("queue_status", "published")
+    print(f"Finalized {item.repository} v{item.candidate_version} without another upload.")
     return 0
 
 
@@ -188,7 +211,7 @@ def reconcile_verification(queue, client, item, args, now) -> int:
 
     try:
         if version_exists(client, item.appid, item.candidate_version):
-            return complete_existing(queue, client, item, args)
+            return finalize_publication(queue, client, item, args, result, now)
     except Exception:
         print("The release listing could not be read; checking the accepted package directly.")
 
@@ -229,7 +252,7 @@ def reconcile_verification(queue, client, item, args, now) -> int:
                 "splunkbase_app_id": splunkbase_app_id,
             }
         )
-        return complete_existing(queue, client, item, args)
+        return finalize_publication(queue, client, item, args, result, now)
 
     if client._is_retryable_response(response) or not Splunkbase.is_definitive_validation_failure(
         response
@@ -269,7 +292,17 @@ def publish_item(args) -> int:
         return reconcile_verification(queue, splunkbase, item, args, now)
 
     if version_exists(splunkbase, item.appid, item.candidate_version):
-        return complete_existing(queue, splunkbase, item, args)
+        return finalize_publication(
+            queue,
+            splunkbase,
+            item,
+            args,
+            {
+                "status": "already_published",
+                "app_existed_before_upload": True,
+            },
+            now,
+        )
 
     retry_at = queue.reserve_attempt(item.publisher_alias, item, now)
     if retry_at:
@@ -293,10 +326,7 @@ def publish_item(args) -> int:
     write_output("request_id", result.get("request_id", ""))
 
     if status in {"published", "new_app", "already_published"}:
-        queue.complete(item, result)
-        queue.delete_asset(item)
-        write_output("queue_status", "published")
-        return 0
+        return finalize_publication(queue, splunkbase, item, args, result, now)
 
     if status == "verifying":
         return defer_verification(
@@ -324,17 +354,14 @@ def publish_item(args) -> int:
     if status == "ambiguous":
         if version_exists(splunkbase, item.appid, item.candidate_version):
             result["status"] = "reconciled_published"
-            queue.complete(item, result)
-            queue.delete_asset(item)
-            write_output("queue_status", "published")
-            return 0
-        queue.requeue(
+            return finalize_publication(queue, splunkbase, item, args, result, now)
+        return defer_verification(
+            queue,
             item,
-            now + MIN_ATTEMPT_INTERVAL,
-            "Ambiguous transport result did not reconcile; retry deferred to a future slot.",
+            result,
+            now,
+            "The upload result is ambiguous; GET-only reconciliation will retry.",
         )
-        write_output("queue_status", "ambiguous")
-        return 0
 
     queue.block(item, result)
     write_output("queue_status", "blocked")

--- a/.github/scripts/drain_splunkbase_publish_queue.py
+++ b/.github/scripts/drain_splunkbase_publish_queue.py
@@ -1,0 +1,314 @@
+"""Select and publish one item from the shared-user Splunkbase queue."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+from packaging.version import parse
+
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+sys.path.insert(0, str(REPO_ROOT))
+
+from utils.api.splunkbase import Splunkbase
+from utils.publish_queue import (
+    MAX_ATTEMPTS_PER_HOUR,
+    MIN_ATTEMPT_INTERVAL,
+    GitHubClient,
+    GitHubIssuePublishQueue,
+    PublishAttempt,
+    format_datetime,
+    parse_datetime,
+    utc_now,
+)
+
+
+def write_output(name: str, value: str | int | bool) -> None:
+    output_path = os.getenv("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with open(output_path, "a") as output:
+        output.write(f"{name}={str(value).lower() if isinstance(value, bool) else value}\n")
+
+
+def queue_from_environment() -> GitHubIssuePublishQueue:
+    return GitHubIssuePublishQueue(
+        GitHubClient(os.environ["GITHUB_TOKEN"]),
+        os.environ["QUEUE_REPOSITORY"],
+    )
+
+
+def select_item(args) -> int:
+    item = queue_from_environment().oldest_eligible(args.publisher_alias, utc_now())
+    write_output("has_item", item is not None)
+    if item is None:
+        print("No eligible Splunkbase publications are queued.")
+        return 0
+
+    write_output("issue_number", item.issue_number)
+    write_output("repository", item.repository)
+    write_output("repository_name", item.repository.split("/")[-1])
+    write_output("commit_sha", item.commit_sha)
+    write_output("asset_name", item.asset_name)
+    write_output("release_tag", item.release_tag)
+    write_output("candidate_version", item.candidate_version)
+    print(f"Selected queue issue #{item.issue_number}: {item.repository} v{item.candidate_version}")
+    return 0
+
+
+def download_item(args) -> int:
+    queue = queue_from_environment()
+    item = queue.get_item(args.issue_number)
+    destination = Path(args.output)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    queue.download_asset(item, destination)
+    print(f"Downloaded {item.asset_name} to {destination}.")
+    return 0
+
+
+def retry_after_datetime(value: str | None, now: datetime) -> datetime:
+    if not value:
+        return now + MIN_ATTEMPT_INTERVAL
+    try:
+        return now + timedelta(seconds=max(int(value), 0))
+    except ValueError:
+        try:
+            return parsedate_to_datetime(value).astimezone(timezone.utc)
+        except (TypeError, ValueError):
+            return now + MIN_ATTEMPT_INTERVAL
+
+
+def version_exists(client: Splunkbase, appid: str, version: str) -> bool:
+    return any(
+        parse(str(release["release_name"])) == parse(version)
+        for release in client.get_existing_releases(appid)
+    )
+
+
+def append_outputs(source: Path) -> None:
+    target = os.getenv("GITHUB_OUTPUT")
+    if target and source.exists():
+        with open(target, "a") as output:
+            output.write(source.read_text())
+
+
+def load_publisher_module():
+    module_path = REPO_ROOT / "actions" / "publish" / "upload_to_splunkbase.py"
+    spec = importlib.util.spec_from_file_location("queued_upload_to_splunkbase", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_publisher(args, item) -> tuple[int, dict]:
+    result_path = Path(args.result_path)
+    publisher_output = Path(args.publisher_output)
+    env = os.environ.copy()
+    env.update(
+        {
+            "UPLOAD_PATH": str(Path(args.artifact).resolve()),
+            "PUBLISH_RESULT_PATH": str(result_path.resolve()),
+            "GITHUB_OUTPUT": str(publisher_output.resolve()),
+            "GITHUB_WORKSPACE": str(Path(args.connector_workspace).resolve()),
+        }
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "actions" / "publish" / "upload_to_splunkbase.py"),
+            item.repository.split("/")[-1],
+        ],
+        cwd=args.connector_workspace,
+        env=env,
+        check=False,
+    )
+    result = json.loads(result_path.read_text()) if result_path.exists() else {"status": "failed"}
+    append_outputs(publisher_output)
+    return completed.returncode, result
+
+
+def complete_existing(queue, client, item, args) -> int:
+    publisher = load_publisher_module()
+    app_json = publisher.get_app_json(args.artifact)
+    release_notes = publisher.get_release_notes(
+        item.candidate_version,
+        Path(args.connector_workspace),
+    ) or publisher.get_release_notes_from_tarball(args.artifact, item.candidate_version)
+    apps = client.get_apps({"appid": item.appid})
+    result = {
+        "status": "already_published",
+        "release_version": item.candidate_version,
+    }
+    if apps:
+        result["splunkbase_app_id"] = apps[0]["id"]
+        write_output("splunk_base_url", f"https://splunkbase.splunk.com/app/{apps[0]['id']}")
+        write_output("support_tag", apps[0]["support"])
+    write_output("app_name", item.app_name)
+    write_output("app_logo", app_json["logo"])
+    write_output("repo_name", item.repository.split("/")[-1])
+    write_output("release_version", item.candidate_version)
+    write_output("release_notes", json.dumps((release_notes or "").split("\n")))
+    write_output("new_app", False)
+    write_output("publish_return_code", 0)
+    write_output("queue_status", "published")
+    queue.complete(item, result)
+    queue.delete_asset(item)
+    print(
+        f"{item.repository} v{item.candidate_version} already exists; "
+        "no upload attempt was consumed."
+    )
+    return 0
+
+
+def publish_item(args) -> int:
+    queue = queue_from_environment()
+    item = queue.get_item(args.issue_number)
+    now = utc_now()
+    splunkbase = Splunkbase(
+        os.environ["SPLUNKBASE_USER"],
+        os.environ["SPLUNKBASE_PASSWORD"],
+        request_context={
+            "repo": item.repository.split("/")[-1],
+            "version": item.candidate_version,
+            "run_id": item.run_id,
+            "run_attempt": item.run_attempt,
+        },
+    )
+
+    if version_exists(splunkbase, item.appid, item.candidate_version):
+        return complete_existing(queue, splunkbase, item, args)
+
+    retry_at = queue.reserve_attempt(item.publisher_alias, item, now)
+    if retry_at:
+        queue.requeue(
+            item,
+            retry_at,
+            f"Per-user upload budget is unavailable until {format_datetime(retry_at)}.",
+        )
+        write_output("queue_status", "deferred")
+        print(f"Upload budget unavailable until {format_datetime(retry_at)}.")
+        return 0
+
+    queue.activate(item, now + timedelta(minutes=15))
+    queue.record_attempt(
+        item,
+        PublishAttempt(started_at=format_datetime(now), outcome="started"),
+    )
+    return_code, result = run_publisher(args, item)
+    status = result.get("status", "failed")
+    write_output("publish_return_code", return_code)
+    write_output("request_id", result.get("request_id", ""))
+
+    if status in {"published", "new_app", "already_published"}:
+        queue.complete(item, result)
+        queue.delete_asset(item)
+        write_output("queue_status", "published")
+        return 0
+
+    if status == "rate_limited":
+        not_before = max(
+            now + MIN_ATTEMPT_INTERVAL,
+            retry_after_datetime(result.get("retry_after"), now) + timedelta(seconds=30),
+        )
+        queue.requeue(
+            item,
+            not_before,
+            "Splunkbase returned HTTP 429; no automatic POST retry was made.",
+            rate_limited=True,
+        )
+        write_output("queue_status", "rate_limited")
+        return 0
+
+    if status == "ambiguous":
+        if version_exists(splunkbase, item.appid, item.candidate_version):
+            result["status"] = "reconciled_published"
+            queue.complete(item, result)
+            queue.delete_asset(item)
+            write_output("queue_status", "published")
+            return 0
+        queue.requeue(
+            item,
+            now + MIN_ATTEMPT_INTERVAL,
+            "Ambiguous transport result did not reconcile; retry deferred to a future slot.",
+        )
+        write_output("queue_status", "ambiguous")
+        return 0
+
+    queue.block(item, result)
+    write_output("queue_status", "blocked")
+    return 1
+
+
+def simulate(args) -> int:
+    raw_items = json.loads(Path(args.queue_file).read_text())
+    slot = parse_datetime(args.now)
+    attempts = []
+    seen = set()
+    for item in raw_items:
+        dedupe_key = (
+            item.get("publisher_alias", args.publisher_alias),
+            item["repository"],
+            item["candidate_version"],
+        )
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+
+        cutoff = slot - timedelta(hours=1)
+        attempts = [attempt for attempt in attempts if attempt > cutoff]
+        if attempts:
+            slot = max(slot, attempts[-1] + MIN_ATTEMPT_INTERVAL)
+        if len(attempts) >= MAX_ATTEMPTS_PER_HOUR:
+            slot = max(slot, attempts[0] + timedelta(hours=1))
+            cutoff = slot - timedelta(hours=1)
+            attempts = [attempt for attempt in attempts if attempt > cutoff]
+
+        print(f"{item['repository']} v{item['candidate_version']} {format_datetime(slot)}")
+        attempts.append(slot)
+    return 0
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    select = subparsers.add_parser("select")
+    select.add_argument("--publisher-alias", default="soar-connectors-default")
+    select.set_defaults(func=select_item)
+
+    publish = subparsers.add_parser("publish")
+    publish.add_argument("--issue-number", type=int, required=True)
+    publish.add_argument("--artifact", required=True)
+    publish.add_argument("--connector-workspace", required=True)
+    publish.add_argument("--result-path", required=True)
+    publish.add_argument("--publisher-output", required=True)
+    publish.set_defaults(func=publish_item)
+
+    download = subparsers.add_parser("download")
+    download.add_argument("--issue-number", type=int, required=True)
+    download.add_argument("--output", required=True)
+    download.set_defaults(func=download_item)
+
+    simulation = subparsers.add_parser("simulate")
+    simulation.add_argument("queue_file")
+    simulation.add_argument("--now", required=True)
+    simulation.add_argument("--publisher-alias", default="soar-connectors-default")
+    simulation.set_defaults(func=simulate)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/drain_splunkbase_publish_queue.py
+++ b/.github/scripts/drain_splunkbase_publish_queue.py
@@ -203,6 +203,30 @@ def defer_verification(queue, item, result, now, reason) -> int:
     return 0
 
 
+def block_publication(queue, item, result, reason, return_code=1) -> int:
+    """Persist a terminal failure and expose sanitized notification fields."""
+
+    queue.block(item, result)
+    write_output("publish_return_code", return_code)
+    write_output("request_id", result.get("request_id", ""))
+    write_output("package_id", result.get("package_id", ""))
+    write_output("failure_reason", reason)
+    write_output("queue_status", "blocked")
+    print(reason)
+    return 1
+
+
+def interrupted_attempt(item) -> dict | None:
+    """Return a counted attempt whose POST outcome was never durably recorded."""
+
+    attempts = getattr(item, "attempts", [])
+    if not attempts or attempts[-1].get("outcome") != "started":
+        return None
+    result = dict(attempts[-1])
+    result["status"] = "verifying"
+    return result
+
+
 def reconcile_verification(queue, client, item, args, now) -> int:
     """Reconcile an accepted package using GETs only."""
 
@@ -266,11 +290,13 @@ def reconcile_verification(queue, client, item, args, now) -> int:
         )
 
     result["status"] = "validation_failed"
-    queue.block(item, result)
-    write_output("publish_return_code", 13)
-    write_output("queue_status", "blocked")
-    print(f"Splunkbase definitively rejected accepted package {package_id}.")
-    return 1
+    return block_publication(
+        queue,
+        item,
+        result,
+        f"Splunkbase definitively rejected accepted package {package_id}.",
+        return_code=13,
+    )
 
 
 def publish_item(args) -> int:
@@ -291,6 +317,22 @@ def publish_item(args) -> int:
     if item.verification:
         return reconcile_verification(queue, splunkbase, item, args, now)
 
+    interrupted = interrupted_attempt(item)
+    if interrupted:
+        try:
+            if version_exists(splunkbase, item.appid, item.candidate_version):
+                return finalize_publication(queue, splunkbase, item, args, interrupted, now)
+        except Exception:
+            pass
+        return defer_verification(
+            queue,
+            item,
+            interrupted,
+            now,
+            "A counted upload attempt ended without a durable result; "
+            "GET-only reconciliation will continue until a human authorizes another POST.",
+        )
+
     if version_exists(splunkbase, item.appid, item.candidate_version):
         return finalize_publication(
             queue,
@@ -302,6 +344,16 @@ def publish_item(args) -> int:
                 "app_existed_before_upload": True,
             },
             now,
+        )
+
+    try:
+        app_existed_before_upload = bool(splunkbase.get_apps({"appid": item.appid}))
+    except Exception:
+        return block_publication(
+            queue,
+            item,
+            {"status": "pre_upload_failed"},
+            "Splunkbase app metadata could not be read before upload; no POST was attempted.",
         )
 
     retry_at = queue.reserve_attempt(item.publisher_alias, item, now)
@@ -318,9 +370,14 @@ def publish_item(args) -> int:
     queue.activate(item, now + timedelta(minutes=15))
     queue.record_attempt(
         item,
-        PublishAttempt(started_at=format_datetime(now), outcome="started"),
+        PublishAttempt(
+            started_at=format_datetime(now),
+            outcome="started",
+            app_existed_before_upload=app_existed_before_upload,
+        ),
     )
     return_code, result = run_publisher(args, item)
+    result["app_existed_before_upload"] = app_existed_before_upload
     status = result.get("status", "failed")
     write_output("publish_return_code", return_code)
     write_output("request_id", result.get("request_id", ""))
@@ -338,6 +395,7 @@ def publish_item(args) -> int:
         )
 
     if status == "rate_limited":
+        item.attempts[-1]["outcome"] = "rate_limited"
         not_before = max(
             now + MIN_ATTEMPT_INTERVAL,
             retry_after_datetime(result.get("retry_after"), now) + timedelta(seconds=30),
@@ -363,9 +421,13 @@ def publish_item(args) -> int:
             "The upload result is ambiguous; GET-only reconciliation will retry.",
         )
 
-    queue.block(item, result)
-    write_output("queue_status", "blocked")
-    return 1
+    return block_publication(
+        queue,
+        item,
+        result,
+        f"Publisher stopped with terminal status {status}.",
+        return_code=return_code,
+    )
 
 
 def simulate(args) -> int:

--- a/.github/scripts/enqueue_splunkbase_publish.py
+++ b/.github/scripts/enqueue_splunkbase_publish.py
@@ -1,0 +1,26 @@
+"""Create or update one durable Splunkbase queue item."""
+
+import json
+import os
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+sys.path.insert(0, str(REPO_ROOT))
+
+from utils.publish_queue import GitHubClient, GitHubIssuePublishQueue, PublishQueueItem
+
+
+def main() -> int:
+    token = os.environ["GITHUB_TOKEN"]
+    repository = os.environ["QUEUE_REPOSITORY"]
+    payload = json.loads(os.environ["QUEUE_ITEM_JSON"])
+    queue = GitHubIssuePublishQueue(GitHubClient(token), repository)
+    item = queue.enqueue(PublishQueueItem.from_dict(payload))
+    print(f"Queued {item.repository} v{item.candidate_version} as issue #{item.issue_number}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/fixtures/publish_queue.json
+++ b/.github/scripts/fixtures/publish_queue.json
@@ -1,0 +1,14 @@
+[
+  {
+    "repository": "splunk-soar-connectors/example-a",
+    "candidate_version": "1.0.1"
+  },
+  {
+    "repository": "splunk-soar-connectors/example-b",
+    "candidate_version": "2.0.0"
+  },
+  {
+    "repository": "splunk-soar-connectors/example-c",
+    "candidate_version": "3.4.5"
+  }
+]

--- a/.github/scripts/notify_splunkbase_publish_failure.py
+++ b/.github/scripts/notify_splunkbase_publish_failure.py
@@ -1,0 +1,53 @@
+"""Notify the internal connector channel about a terminal queue failure."""
+
+from __future__ import annotations
+
+import os
+
+import requests
+
+
+def build_message(environment: dict[str, str]) -> str:
+    request_id = environment.get("SPLUNKBASE_REQUEST_ID") or "unavailable"
+    package_id = environment.get("SPLUNKBASE_PACKAGE_ID") or "unavailable"
+    return "\n".join(
+        [
+            ":warning: Splunkbase connector publication blocked",
+            (
+                f"Repository: {environment['CONNECTOR_REPOSITORY']} "
+                f"v{environment['CONNECTOR_VERSION']}"
+            ),
+            f"Queue item: {environment['QUEUE_ISSUE_URL']}",
+            f"Request ID: {request_id}",
+            f"Package ID: {package_id}",
+            f"Reason: {environment['FAILURE_REASON']}",
+            "Automated by the Codex-authored Splunkbase publish queue.",
+        ]
+    )
+
+
+def main() -> None:
+    response = requests.post(
+        "https://slack.com/api/chat.postMessage",
+        headers={
+            "Authorization": f"Bearer {os.environ['SLACK_INTERNAL_TOKEN']}",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+        json={
+            "channel": os.environ["SLACK_INTERNAL_CHANNEL"],
+            "text": build_message(os.environ),
+            "unfurl_links": False,
+            "unfurl_media": False,
+        },
+        timeout=(10, 30),
+    )
+    response.raise_for_status()
+    payload = response.json()
+    if not payload.get("ok"):
+        raise RuntimeError(
+            f"Slack rejected publication failure notification: {payload.get('error')}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_drain_splunkbase_publish_queue.py
+++ b/.github/scripts/test_drain_splunkbase_publish_queue.py
@@ -1,6 +1,9 @@
 import importlib.util
 import json
 from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
 
 
 MODULE_PATH = Path(__file__).with_name("drain_splunkbase_publish_queue.py")
@@ -49,3 +52,145 @@ def test_simulation_deduplicates_and_respects_hourly_budget(tmp_path, capsys):
     assert lines[0].endswith("2026-07-29T12:00:00Z")
     assert lines[11].endswith("2026-07-29T12:55:00Z")
     assert lines[12].endswith("2026-07-29T13:00:00Z")
+
+
+def verifying_item():
+    return type(
+        "Item",
+        (),
+        {
+            "verification": {
+                "status": "verifying",
+                "package_id": "package-123",
+                "request_id": "request-123",
+            },
+            "appid": "example-guid",
+            "candidate_version": "1.2.3",
+        },
+    )()
+
+
+@pytest.mark.parametrize(
+    "validation_error",
+    [
+        TimeoutError("validation timed out"),
+        ConnectionError("validation connection failed"),
+        RuntimeError("validation GET exhausted 5xx retries"),
+        ValueError("validation response was not JSON"),
+    ],
+)
+def test_verification_get_failures_do_not_post_or_reserve(monkeypatch, validation_error):
+    queue = Mock()
+    client = Mock()
+    client.get_existing_releases.return_value = []
+    client.check_upload_status.side_effect = validation_error
+    run_publisher = Mock()
+    monkeypatch.setattr(MODULE, "run_publisher", run_publisher)
+
+    result = MODULE.reconcile_verification(
+        queue,
+        client,
+        verifying_item(),
+        object(),
+        MODULE.parse_datetime("2026-07-29T12:00:00Z"),
+    )
+
+    assert result == 0
+    queue.verify.assert_called_once()
+    queue.reserve_attempt.assert_not_called()
+    run_publisher.assert_not_called()
+
+
+def test_eventual_version_appearance_completes_without_post_or_reserve(monkeypatch):
+    queue = Mock()
+    client = Mock()
+    client.get_existing_releases.return_value = [{"release_name": "1.2.3"}]
+    complete_existing = Mock(return_value=0)
+    run_publisher = Mock()
+    monkeypatch.setattr(MODULE, "complete_existing", complete_existing)
+    monkeypatch.setattr(MODULE, "run_publisher", run_publisher)
+
+    result = MODULE.reconcile_verification(
+        queue,
+        client,
+        verifying_item(),
+        object(),
+        MODULE.parse_datetime("2026-07-29T12:00:00Z"),
+    )
+
+    assert result == 0
+    complete_existing.assert_called_once()
+    client.check_upload_status.assert_not_called()
+    queue.reserve_attempt.assert_not_called()
+    run_publisher.assert_not_called()
+
+
+def test_continued_pending_validation_does_not_post_or_reserve(monkeypatch):
+    queue = Mock()
+    client = Mock()
+    client.get_existing_releases.return_value = []
+    client.check_upload_status.return_value = {"message": "Package validation still in progress."}
+    client._is_retryable_response.return_value = True
+    run_publisher = Mock()
+    monkeypatch.setattr(MODULE, "run_publisher", run_publisher)
+
+    result = MODULE.reconcile_verification(
+        queue,
+        client,
+        verifying_item(),
+        object(),
+        MODULE.parse_datetime("2026-07-29T12:00:00Z"),
+    )
+
+    assert result == 0
+    queue.verify.assert_called_once()
+    queue.reserve_attempt.assert_not_called()
+    run_publisher.assert_not_called()
+
+
+def test_definitive_rejection_blocks_without_post_or_reserve(monkeypatch):
+    queue = Mock()
+    client = Mock()
+    client.get_existing_releases.return_value = []
+    client.check_upload_status.return_value = {"message": "Package failed validation."}
+    client._is_retryable_response.return_value = False
+    run_publisher = Mock()
+    monkeypatch.setattr(MODULE, "run_publisher", run_publisher)
+
+    result = MODULE.reconcile_verification(
+        queue,
+        client,
+        verifying_item(),
+        object(),
+        MODULE.parse_datetime("2026-07-29T12:00:00Z"),
+    )
+
+    assert result == 1
+    queue.block.assert_called_once()
+    queue.reserve_attempt.assert_not_called()
+    run_publisher.assert_not_called()
+
+
+@pytest.mark.parametrize("response", [{}, {"message": "unknown"}, ["malformed"]])
+def test_inconclusive_status_does_not_post_or_reserve(monkeypatch, response):
+    queue = Mock()
+    client = Mock()
+    client.get_existing_releases.return_value = []
+    client.check_upload_status.return_value = response
+    client._is_retryable_response.return_value = False
+    run_publisher = Mock()
+    monkeypatch.setattr(MODULE, "run_publisher", run_publisher)
+
+    result = MODULE.reconcile_verification(
+        queue,
+        client,
+        verifying_item(),
+        object(),
+        MODULE.parse_datetime("2026-07-29T12:00:00Z"),
+    )
+
+    assert result == 0
+    queue.verify.assert_called_once()
+    queue.block.assert_not_called()
+    queue.reserve_attempt.assert_not_called()
+    run_publisher.assert_not_called()

--- a/.github/scripts/test_drain_splunkbase_publish_queue.py
+++ b/.github/scripts/test_drain_splunkbase_publish_queue.py
@@ -165,6 +165,57 @@ def test_recovery_paths_share_finalization_without_post_or_reserve(
     run_publisher.assert_not_called()
 
 
+def test_ambiguous_upload_is_finalized_when_version_appears_without_second_post(
+    monkeypatch,
+):
+    queue = Mock()
+    item = verifying_item()
+    item.verification = None
+    queue.get_item.return_value = item
+    queue.reserve_attempt.return_value = None
+    client = Mock()
+    client.get_existing_releases.side_effect = [
+        [],
+        [],
+        [{"release_name": "1.2.3"}],
+    ]
+    client.get_apps.return_value = [{"id": "app-123", "support": "splunk"}]
+    run_publisher = Mock(
+        return_value=(
+            12,
+            {
+                "status": "ambiguous",
+                "app_existed_before_upload": False,
+                "request_id": "request-123",
+            },
+        )
+    )
+    outputs = {}
+    monkeypatch.setattr(MODULE, "queue_from_environment", lambda: queue)
+    monkeypatch.setattr(MODULE, "Splunkbase", lambda *args, **kwargs: client)
+    monkeypatch.setattr(MODULE, "load_publisher_module", publisher_metadata)
+    monkeypatch.setattr(MODULE, "run_publisher", run_publisher)
+    monkeypatch.setattr(MODULE, "write_output", outputs.__setitem__)
+    monkeypatch.setenv("SPLUNKBASE_USER", "publisher")
+    monkeypatch.setenv("SPLUNKBASE_PASSWORD", "password")
+
+    assert MODULE.publish_item(finalization_args()) == 0
+    verification_result = queue.verify.call_args.args[1]
+    item.verification = verification_result
+
+    assert MODULE.publish_item(finalization_args()) == 0
+
+    assert run_publisher.call_count == 1
+    assert queue.reserve_attempt.call_count == 1
+    assert outputs["new_app"] is True
+    assert outputs["publish_return_code"] == 2
+    assert outputs["support_tag"] == "splunk"
+    assert outputs["splunk_base_url"] == "https://splunkbase.splunk.com/app/app-123"
+    client.ensure_app_editors.assert_called_once_with("app-123")
+    queue.complete.assert_called_once()
+    queue.delete_asset.assert_called_once_with(item)
+
+
 def test_continued_pending_validation_does_not_post_or_reserve(monkeypatch):
     queue = Mock()
     client = Mock()

--- a/.github/scripts/test_drain_splunkbase_publish_queue.py
+++ b/.github/scripts/test_drain_splunkbase_publish_queue.py
@@ -65,7 +65,13 @@ def verifying_item():
                 "request_id": "request-123",
             },
             "appid": "example-guid",
+            "app_name": "Example",
             "candidate_version": "1.2.3",
+            "issue_number": 1,
+            "publisher_alias": "soar-connectors-default",
+            "repository": "splunk-soar-connectors/example",
+            "run_attempt": 2,
+            "run_id": 123,
         },
     )()
 
@@ -101,26 +107,60 @@ def test_verification_get_failures_do_not_post_or_reserve(monkeypatch, validatio
     run_publisher.assert_not_called()
 
 
-def test_eventual_version_appearance_completes_without_post_or_reserve(monkeypatch):
+@pytest.mark.parametrize(
+    ("entry_path", "existed_before", "expected_new_app"),
+    [
+        ("preexisting", True, False),
+        ("recovered", True, False),
+        ("recovered", False, True),
+    ],
+)
+def test_recovery_paths_share_finalization_without_post_or_reserve(
+    monkeypatch,
+    entry_path,
+    existed_before,
+    expected_new_app,
+):
     queue = Mock()
     client = Mock()
     client.get_existing_releases.return_value = [{"release_name": "1.2.3"}]
-    complete_existing = Mock(return_value=0)
+    client.get_apps.return_value = [{"id": "app-123", "support": "splunk"}]
     run_publisher = Mock()
-    monkeypatch.setattr(MODULE, "complete_existing", complete_existing)
+    outputs = {}
+    monkeypatch.setattr(MODULE, "load_publisher_module", publisher_metadata)
+    monkeypatch.setattr(MODULE, "write_output", outputs.__setitem__)
     monkeypatch.setattr(MODULE, "run_publisher", run_publisher)
+    item = verifying_item()
 
-    result = MODULE.reconcile_verification(
-        queue,
-        client,
-        verifying_item(),
-        object(),
-        MODULE.parse_datetime("2026-07-29T12:00:00Z"),
-    )
+    if entry_path == "recovered":
+        item.verification["app_existed_before_upload"] = existed_before
+        result = MODULE.reconcile_verification(
+            queue,
+            client,
+            item,
+            finalization_args(),
+            MODULE.parse_datetime("2026-07-29T12:00:00Z"),
+        )
+    else:
+        item.verification = None
+        queue.get_item.return_value = item
+        monkeypatch.setattr(MODULE, "queue_from_environment", lambda: queue)
+        monkeypatch.setattr(MODULE, "Splunkbase", lambda *args, **kwargs: client)
+        monkeypatch.setenv("SPLUNKBASE_USER", "publisher")
+        monkeypatch.setenv("SPLUNKBASE_PASSWORD", "password")
+        result = MODULE.publish_item(finalization_args())
 
     assert result == 0
-    complete_existing.assert_called_once()
     client.check_upload_status.assert_not_called()
+    if expected_new_app:
+        client.ensure_app_editors.assert_called_once_with("app-123")
+    else:
+        client.ensure_app_editors.assert_not_called()
+    assert outputs["new_app"] is expected_new_app
+    assert outputs["support_tag"] == "splunk"
+    assert outputs["splunk_base_url"] == "https://splunkbase.splunk.com/app/app-123"
+    queue.complete.assert_called_once()
+    queue.delete_asset.assert_called_once_with(item)
     queue.reserve_attempt.assert_not_called()
     run_publisher.assert_not_called()
 
@@ -194,3 +234,151 @@ def test_inconclusive_status_does_not_post_or_reserve(monkeypatch, response):
     queue.block.assert_not_called()
     queue.reserve_attempt.assert_not_called()
     run_publisher.assert_not_called()
+
+
+def test_run_publisher_passes_queued_source_identity(tmp_path, monkeypatch):
+    captured = {}
+    result_path = tmp_path / "result.json"
+    publisher_output = tmp_path / "publisher-output"
+    connector_workspace = tmp_path / "connector"
+    connector_workspace.mkdir()
+    args = type(
+        "Args",
+        (),
+        {
+            "artifact": str(tmp_path / "example.tgz"),
+            "result_path": str(result_path),
+            "publisher_output": str(publisher_output),
+            "connector_workspace": str(connector_workspace),
+        },
+    )()
+    item = type(
+        "Item",
+        (),
+        {
+            "repository": "splunk-soar-connectors/example",
+            "run_id": 12345,
+            "run_attempt": 3,
+        },
+    )()
+
+    def fake_run(command, cwd, env, check):
+        captured.update(env)
+        result_path.write_text('{"status": "verifying"}')
+        return type("Completed", (), {"returncode": 14})()
+
+    monkeypatch.setattr(MODULE.subprocess, "run", fake_run)
+    monkeypatch.setenv("GITHUB_RUN_ID", "worker-run")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "9")
+
+    return_code, result = MODULE.run_publisher(args, item)
+
+    assert return_code == 14
+    assert result == {"status": "verifying"}
+    assert captured["SOURCE_GITHUB_RUN_ID"] == "12345"
+    assert captured["SOURCE_GITHUB_RUN_ATTEMPT"] == "3"
+    assert captured["GITHUB_RUN_ID"] == "worker-run"
+    assert captured["GITHUB_RUN_ATTEMPT"] == "9"
+
+
+def finalization_args():
+    return type(
+        "Args",
+        (),
+        {
+            "artifact": "/tmp/example.tgz",
+            "connector_workspace": "/tmp/example",
+            "issue_number": 1,
+        },
+    )()
+
+
+def publisher_metadata():
+    return type(
+        "Publisher",
+        (),
+        {
+            "get_app_json": staticmethod(lambda artifact: {"logo": "example.svg"}),
+            "get_release_notes": staticmethod(lambda version, workspace: "* Fixed publication."),
+            "get_release_notes_from_tarball": staticmethod(lambda artifact, version: None),
+        },
+    )()
+
+
+@pytest.mark.parametrize(
+    ("existed_before", "expected_new_app", "expected_return_code"),
+    [(True, False, 0), (False, True, 2)],
+)
+def test_finalization_reconstructs_outputs_and_new_app_side_effects(
+    monkeypatch,
+    existed_before,
+    expected_new_app,
+    expected_return_code,
+):
+    queue = Mock()
+    client = Mock()
+    client.get_apps.return_value = [{"id": "app-123", "support": "splunk"}]
+    outputs = {}
+    monkeypatch.setattr(MODULE, "load_publisher_module", publisher_metadata)
+    monkeypatch.setattr(MODULE, "write_output", outputs.__setitem__)
+    item = verifying_item()
+    result = {
+        "status": "verifying",
+        "package_id": "package-123",
+        "app_existed_before_upload": existed_before,
+    }
+
+    assert (
+        MODULE.finalize_publication(
+            queue,
+            client,
+            item,
+            finalization_args(),
+            result,
+            MODULE.parse_datetime("2026-07-29T12:00:00Z"),
+        )
+        == 0
+    )
+
+    if expected_new_app:
+        client.ensure_app_editors.assert_called_once_with("app-123")
+    else:
+        client.ensure_app_editors.assert_not_called()
+    assert outputs["new_app"] is expected_new_app
+    assert outputs["publish_return_code"] == expected_return_code
+    assert outputs["support_tag"] == "splunk"
+    assert outputs["splunk_base_url"] == "https://splunkbase.splunk.com/app/app-123"
+    queue.complete.assert_called_once()
+    queue.delete_asset.assert_called_once_with(item)
+
+
+@pytest.mark.parametrize("failure_point", ["metadata", "editors"])
+def test_finalization_failure_retains_artifact_and_requeues(monkeypatch, failure_point):
+    queue = Mock()
+    client = Mock()
+    client.get_apps.return_value = [{"id": "app-123", "support": "splunk"}]
+    if failure_point == "metadata":
+        client.get_apps.side_effect = RuntimeError("metadata unavailable")
+    else:
+        client.ensure_app_editors.side_effect = RuntimeError("editor unavailable")
+    monkeypatch.setattr(MODULE, "load_publisher_module", publisher_metadata)
+    item = verifying_item()
+
+    assert (
+        MODULE.finalize_publication(
+            queue,
+            client,
+            item,
+            finalization_args(),
+            {
+                "status": "verifying",
+                "app_existed_before_upload": False,
+            },
+            MODULE.parse_datetime("2026-07-29T12:00:00Z"),
+        )
+        == 0
+    )
+
+    queue.verify.assert_called_once()
+    queue.complete.assert_not_called()
+    queue.delete_asset.assert_not_called()

--- a/.github/scripts/test_drain_splunkbase_publish_queue.py
+++ b/.github/scripts/test_drain_splunkbase_publish_queue.py
@@ -1,0 +1,51 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("drain_splunkbase_publish_queue.py")
+SPEC = importlib.util.spec_from_file_location("drain_splunkbase_publish_queue", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_retry_after_supports_seconds_and_http_dates():
+    now = MODULE.parse_datetime("2026-07-29T12:00:00Z")
+
+    assert MODULE.format_datetime(MODULE.retry_after_datetime("300", now)) == (
+        "2026-07-29T12:05:00Z"
+    )
+    assert (
+        MODULE.format_datetime(MODULE.retry_after_datetime("Wed, 29 Jul 2026 12:07:00 GMT", now))
+        == "2026-07-29T12:07:00Z"
+    )
+
+
+def test_simulation_deduplicates_and_respects_hourly_budget(tmp_path, capsys):
+    queue = [
+        {
+            "repository": f"splunk-soar-connectors/repo-{index:02}",
+            "candidate_version": "1.0.0",
+        }
+        for index in range(13)
+    ]
+    queue.append(queue[0])
+    queue_file = tmp_path / "queue.json"
+    queue_file.write_text(json.dumps(queue))
+    args = type(
+        "Args",
+        (),
+        {
+            "queue_file": str(queue_file),
+            "now": "2026-07-29T12:00:00Z",
+            "publisher_alias": "soar-connectors-default",
+        },
+    )
+
+    assert MODULE.simulate(args) == 0
+
+    lines = capsys.readouterr().out.splitlines()
+    assert len(lines) == 13
+    assert lines[0].endswith("2026-07-29T12:00:00Z")
+    assert lines[11].endswith("2026-07-29T12:55:00Z")
+    assert lines[12].endswith("2026-07-29T13:00:00Z")

--- a/.github/scripts/test_drain_splunkbase_publish_queue.py
+++ b/.github/scripts/test_drain_splunkbase_publish_queue.py
@@ -76,6 +76,19 @@ def verifying_item():
     )()
 
 
+def interrupted_item():
+    item = verifying_item()
+    item.verification = None
+    item.attempts = [
+        {
+            "started_at": "2026-07-29T12:00:00Z",
+            "outcome": "started",
+            "app_existed_before_upload": False,
+        }
+    ]
+    return item
+
+
 @pytest.mark.parametrize(
     "validation_error",
     [
@@ -179,7 +192,10 @@ def test_ambiguous_upload_is_finalized_when_version_appears_without_second_post(
         [],
         [{"release_name": "1.2.3"}],
     ]
-    client.get_apps.return_value = [{"id": "app-123", "support": "splunk"}]
+    client.get_apps.side_effect = [
+        [],
+        [{"id": "app-123", "support": "splunk"}],
+    ]
     run_publisher = Mock(
         return_value=(
             12,
@@ -216,6 +232,109 @@ def test_ambiguous_upload_is_finalized_when_version_appears_without_second_post(
     queue.delete_asset.assert_called_once_with(item)
 
 
+def test_hard_exit_after_counted_attempt_recovers_new_app_without_second_post(
+    monkeypatch,
+):
+    queue = Mock()
+    item = interrupted_item()
+    queue.get_item.return_value = item
+    client = Mock()
+    client.get_existing_releases.side_effect = [
+        [],
+        [{"release_name": "1.2.3"}],
+    ]
+    client.get_apps.return_value = [{"id": "app-123", "support": "splunk"}]
+    run_publisher = Mock()
+    outputs = {}
+    monkeypatch.setattr(MODULE, "queue_from_environment", lambda: queue)
+    monkeypatch.setattr(MODULE, "Splunkbase", lambda *args, **kwargs: client)
+    monkeypatch.setattr(MODULE, "load_publisher_module", publisher_metadata)
+    monkeypatch.setattr(MODULE, "run_publisher", run_publisher)
+    monkeypatch.setattr(MODULE, "write_output", outputs.__setitem__)
+    monkeypatch.setenv("SPLUNKBASE_USER", "publisher")
+    monkeypatch.setenv("SPLUNKBASE_PASSWORD", "password")
+
+    assert MODULE.publish_item(finalization_args()) == 0
+    item.verification = queue.verify.call_args.args[1]
+    assert item.verification["app_existed_before_upload"] is False
+
+    assert MODULE.publish_item(finalization_args()) == 0
+
+    queue.reserve_attempt.assert_not_called()
+    run_publisher.assert_not_called()
+    client.ensure_app_editors.assert_called_once_with("app-123")
+    assert outputs["new_app"] is True
+    queue.complete.assert_called_once()
+
+
+def test_app_existence_snapshot_is_persisted_before_publisher_runs(monkeypatch):
+    queue = Mock()
+    item = interrupted_item()
+    item.attempts = []
+    queue.get_item.return_value = item
+    queue.reserve_attempt.return_value = None
+    client = Mock()
+    client.get_existing_releases.return_value = []
+    client.get_apps.return_value = []
+    events = []
+
+    def record_attempt(recorded_item, attempt):
+        events.append("recorded")
+        recorded_item.attempts.append(
+            {
+                "started_at": attempt.started_at,
+                "outcome": attempt.outcome,
+                "app_existed_before_upload": attempt.app_existed_before_upload,
+            }
+        )
+
+    def run_publisher(args, published_item):
+        events.append("publisher")
+        return 14, {"status": "verifying"}
+
+    outputs = {}
+    queue.record_attempt.side_effect = record_attempt
+    monkeypatch.setattr(MODULE, "queue_from_environment", lambda: queue)
+    monkeypatch.setattr(MODULE, "Splunkbase", lambda *args, **kwargs: client)
+    monkeypatch.setattr(MODULE, "run_publisher", run_publisher)
+    monkeypatch.setattr(MODULE, "write_output", outputs.__setitem__)
+    monkeypatch.setenv("SPLUNKBASE_USER", "publisher")
+    monkeypatch.setenv("SPLUNKBASE_PASSWORD", "password")
+
+    assert MODULE.publish_item(finalization_args()) == 0
+
+    assert events == ["recorded", "publisher"]
+    assert item.attempts[-1]["app_existed_before_upload"] is False
+    queue.verify.assert_called_once()
+    assert outputs["queue_status"] == "verifying"
+
+
+def test_pre_upload_metadata_failure_blocks_without_reserving_or_posting(monkeypatch):
+    queue = Mock()
+    item = interrupted_item()
+    item.attempts = []
+    queue.get_item.return_value = item
+    client = Mock()
+    client.get_existing_releases.return_value = []
+    client.get_apps.side_effect = RuntimeError("metadata unavailable")
+    run_publisher = Mock()
+    outputs = {}
+    monkeypatch.setattr(MODULE, "queue_from_environment", lambda: queue)
+    monkeypatch.setattr(MODULE, "Splunkbase", lambda *args, **kwargs: client)
+    monkeypatch.setattr(MODULE, "run_publisher", run_publisher)
+    monkeypatch.setattr(MODULE, "write_output", outputs.__setitem__)
+    monkeypatch.setenv("SPLUNKBASE_USER", "publisher")
+    monkeypatch.setenv("SPLUNKBASE_PASSWORD", "password")
+
+    assert MODULE.publish_item(finalization_args()) == 1
+
+    queue.block.assert_called_once()
+    queue.reserve_attempt.assert_not_called()
+    run_publisher.assert_not_called()
+    assert outputs["queue_status"] == "blocked"
+    assert outputs["failure_reason"].startswith("Splunkbase app metadata")
+
+
 def test_continued_pending_validation_does_not_post_or_reserve(monkeypatch):
     queue = Mock()
     client = Mock()
@@ -246,7 +365,9 @@ def test_definitive_rejection_blocks_without_post_or_reserve(monkeypatch):
     client.check_upload_status.return_value = {"message": "Package failed validation."}
     client._is_retryable_response.return_value = False
     run_publisher = Mock()
+    outputs = {}
     monkeypatch.setattr(MODULE, "run_publisher", run_publisher)
+    monkeypatch.setattr(MODULE, "write_output", outputs.__setitem__)
 
     result = MODULE.reconcile_verification(
         queue,
@@ -260,6 +381,9 @@ def test_definitive_rejection_blocks_without_post_or_reserve(monkeypatch):
     queue.block.assert_called_once()
     queue.reserve_attempt.assert_not_called()
     run_publisher.assert_not_called()
+    assert outputs["queue_status"] == "blocked"
+    assert outputs["package_id"] == "package-123"
+    assert outputs["failure_reason"].startswith("Splunkbase definitively rejected")
 
 
 @pytest.mark.parametrize("response", [{}, {"message": "unknown"}, ["malformed"]])

--- a/.github/scripts/test_notify_splunkbase_publish_failure.py
+++ b/.github/scripts/test_notify_splunkbase_publish_failure.py
@@ -1,0 +1,49 @@
+import importlib.util
+from pathlib import Path
+from unittest.mock import Mock
+
+
+MODULE_PATH = Path(__file__).with_name("notify_splunkbase_publish_failure.py")
+SPEC = importlib.util.spec_from_file_location("notify_splunkbase_publish_failure", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def environment(**overrides):
+    values = {
+        "SLACK_INTERNAL_TOKEN": "token",
+        "SLACK_INTERNAL_CHANNEL": "C123",
+        "QUEUE_ISSUE_URL": "https://github.com/splunk-soar-connectors/.github/issues/10",
+        "CONNECTOR_REPOSITORY": "splunk-soar-connectors/example",
+        "CONNECTOR_VERSION": "1.2.3",
+        "SPLUNKBASE_REQUEST_ID": "request-123",
+        "SPLUNKBASE_PACKAGE_ID": "package-123",
+        "FAILURE_REASON": "Splunkbase definitively rejected the package.",
+    }
+    values.update(overrides)
+    return values
+
+
+def test_message_contains_tracking_fields_and_codex_attribution():
+    message = MODULE.build_message(environment())
+
+    assert "splunk-soar-connectors/example v1.2.3" in message
+    assert "request-123" in message
+    assert "package-123" in message
+    assert "/issues/10" in message
+    assert "Codex-authored" in message
+
+
+def test_main_posts_one_internal_notification(monkeypatch):
+    response = Mock()
+    response.json.return_value = {"ok": True}
+    post = Mock(return_value=response)
+    monkeypatch.setattr(MODULE.requests, "post", post)
+    for key, value in environment().items():
+        monkeypatch.setenv(key, value)
+
+    MODULE.main()
+
+    post.assert_called_once()
+    assert post.call_args.kwargs["json"]["channel"] == "C123"
+    response.raise_for_status.assert_called_once()

--- a/.github/test_publish_workflow.py
+++ b/.github/test_publish_workflow.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).parent / "workflows" / "publish.yml"
+
+
+def test_enqueue_uses_the_commit_that_created_the_artifact():
+    workflow = WORKFLOW.read_text()
+    build = workflow.split("\n  build:\n", 1)[1].split("\n  publish:\n", 1)[0]
+    enqueue = workflow.split("\n  enqueue-publish:\n", 1)[1].split("\n  metrics:\n", 1)[0]
+
+    assert "commit_sha: ${{ steps.source.outputs.commit_sha }}" in build
+    assert 'echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"' in build
+    assert "commit_sha: ${{ needs.build.outputs.commit_sha }}" in enqueue
+    assert "actions/checkout" not in enqueue

--- a/.github/test_publish_workflow.py
+++ b/.github/test_publish_workflow.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 
 WORKFLOW = Path(__file__).parent / "workflows" / "publish.yml"
+DRAIN_WORKFLOW = Path(__file__).parent / "workflows" / "drain-splunkbase-publish-queue.yml"
 
 
 def test_enqueue_uses_the_commit_that_created_the_artifact():
@@ -13,3 +14,21 @@ def test_enqueue_uses_the_commit_that_created_the_artifact():
     assert 'echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"' in build
     assert "commit_sha: ${{ needs.build.outputs.commit_sha }}" in enqueue
     assert "actions/checkout" not in enqueue
+
+
+def test_drain_notifies_internal_slack_only_for_terminal_blocked_items():
+    workflow = DRAIN_WORKFLOW.read_text()
+    notification = workflow.split(
+        "\n      - name: Notify internal Slack of blocked publication\n",
+        1,
+    )[1]
+
+    assert "if: always() && steps.publish.outputs.queue_status == 'blocked'" in notification
+    assert "SLACK_INTERNAL_TOKEN: ${{ secrets.SLACK_INTERNAL_TOKEN }}" in notification
+    assert "QUEUE_ISSUE_URL:" in notification
+    assert "SPLUNKBASE_REQUEST_ID:" in notification
+    assert "SPLUNKBASE_PACKAGE_ID:" in notification
+    assert "FAILURE_REASON:" in notification
+    assert "queue_status == 'verifying'" not in notification
+    assert "queue_status == 'deferred'" not in notification
+    assert "queue_status == 'rate_limited'" not in notification

--- a/.github/utils/api/splunkbase.py
+++ b/.github/utils/api/splunkbase.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Optional, Union
 import backoff
 import requests
@@ -13,7 +14,7 @@ SGT_LICENSE_STRING = "Splunk General Terms"
 SGT_LICENSE_URL = "https://www.splunk.com/en_us/legal/splunk-general-terms.html"
 APP_REPO_BASE_URL = "https://github.com/splunk-soar-connectors/"
 
-POST_WITH_FILES_NUM_RETRIES = 10
+READ_REQUEST_NUM_RETRIES = 10
 REQUEST_TIMEOUT = (10, 60)
 USER_AGENT = (
     "Splunk-SOAR-Connector-Publisher/1.0 (+https://github.com/splunk-soar-connectors/.github)"
@@ -29,7 +30,7 @@ SPLUNKBASE_SUCCESSFUL_UPLOAD_RESPONSES = [
 SPLUNKBASE_BASE_URL = f"https://splunkbase.splunk.com/api/{SPLUNKBASE_API_VERSION}/apps"
 SPLUNKBASE_EDITOR_URL = "https://splunkbase.splunk.com/api/v0.1/app/{sb_appid}/editors/"
 SPLUNKBASE_LOGIN_URL = "https://api.splunk.com/2.0/rest/login/splunk"
-STATUS_CODES_TO_RETRY = [403, 429, 500, 502, 503, 504]
+READ_STATUS_CODES_TO_RETRY = [429, 500, 502, 503, 504]
 RESPONSE_MESSAGES_TO_RETRY = [
     "Network error communicating with endpoint",
     "Endpoint request timed out",
@@ -42,7 +43,89 @@ class SplunkbaseResponseError(RuntimeError):
     """Raised when Splunkbase returns a response that cannot be consumed safely."""
 
 
-def _retrying_session(headers=None, auth=None, retry_codes=None):
+class SplunkbaseUploadError(RuntimeError):
+    """Base class for a single failed Splunkbase upload attempt."""
+
+    def __init__(
+        self,
+        message,
+        *,
+        status_code=None,
+        retry_after=None,
+        request_id=None,
+    ):
+        super().__init__(message)
+        self.status_code = status_code
+        self.retry_after = retry_after
+        self.request_id = request_id
+
+
+class SplunkbaseRateLimited(SplunkbaseUploadError):
+    """Raised when Splunkbase rejects the counted attempt with HTTP 429."""
+
+
+class SplunkbasePermissionDenied(SplunkbaseUploadError):
+    """Raised when the publishing identity cannot upload the connector."""
+
+
+class SplunkbaseAmbiguousUpload(SplunkbaseUploadError):
+    """Raised when a counted attempt may have reached Splunkbase."""
+
+
+class SplunkbaseValidationFailed(SplunkbaseUploadError):
+    """Raised when Splunkbase definitively rejects the submitted package."""
+
+
+def build_user_agent(repo=None, version=None, run_id=None, run_attempt=None):
+    """Return a stable, non-secret User-Agent with release correlation fields."""
+
+    fields = {
+        "repo": repo or os.getenv("GITHUB_REPOSITORY", "").split("/")[-1],
+        "version": version,
+        "run": run_id or os.getenv("GITHUB_RUN_ID"),
+        "attempt": run_attempt or os.getenv("GITHUB_RUN_ATTEMPT"),
+    }
+    suffix = " ".join(
+        f"{key}/{str(value).replace(' ', '_')}"
+        for key, value in fields.items()
+        if value not in (None, "")
+    )
+    return f"{USER_AGENT} {suffix}".rstrip()
+
+
+def _request_id(response):
+    normalized_headers = {key.lower(): value for key, value in response.headers.items()}
+    for header in (
+        "x-request-id",
+        "x-correlation-id",
+        "splunk-request-id",
+        "request-id",
+    ):
+        value = normalized_headers.get(header)
+        if value:
+            return value
+    return None
+
+
+def _log_response_metadata(response):
+    metadata = {
+        header: response.headers.get(header)
+        for header in (
+            "Retry-After",
+            "X-RateLimit-Limit",
+            "X-RateLimit-Remaining",
+            "X-RateLimit-Reset",
+            "X-Request-ID",
+            "X-Correlation-ID",
+            "Splunk-Request-ID",
+        )
+        if response.headers.get(header)
+    }
+    if metadata:
+        logging.info("Splunkbase response metadata: %s", metadata)
+
+
+def _retrying_session(headers=None, auth=None):
     session = requests.Session()
     session.headers.update({"User-Agent": USER_AGENT})
     if headers:
@@ -51,16 +134,29 @@ def _retrying_session(headers=None, auth=None, retry_codes=None):
         session.auth = auth
 
     retry = Retry(
-        total=POST_WITH_FILES_NUM_RETRIES,
-        connect=POST_WITH_FILES_NUM_RETRIES,
-        read=POST_WITH_FILES_NUM_RETRIES,
-        status=POST_WITH_FILES_NUM_RETRIES,
-        allowed_methods=frozenset(["GET", "POST"]),
-        status_forcelist=retry_codes or STATUS_CODES_TO_RETRY,
+        total=READ_REQUEST_NUM_RETRIES,
+        connect=READ_REQUEST_NUM_RETRIES,
+        read=READ_REQUEST_NUM_RETRIES,
+        status=READ_REQUEST_NUM_RETRIES,
+        allowed_methods=frozenset(["GET"]),
+        status_forcelist=READ_STATUS_CODES_TO_RETRY,
         backoff_factor=1,
         respect_retry_after_header=True,
         raise_on_status=False,
     )
+    session.mount("https://", HTTPAdapter(max_retries=retry))
+    return session
+
+
+def _single_attempt_session(headers=None, auth=None, user_agent=None):
+    session = requests.Session()
+    session.headers.update({"User-Agent": user_agent or USER_AGENT})
+    if headers:
+        session.headers.update(headers)
+    if auth:
+        session.auth = auth
+
+    retry = Retry(total=0, connect=0, read=0, status=0, redirect=0)
     session.mount("https://", HTTPAdapter(max_retries=retry))
     return session
 
@@ -88,19 +184,65 @@ def _post_request(
     data: Union[str, bytes, bool, list, dict],
     check_response: bool = True,
 ) -> Union[list, dict, str, bool]:
-    session = _retrying_session(headers=headers)
+    session = _single_attempt_session(headers=headers)
     response = session.post(url, data, timeout=REQUEST_TIMEOUT)
     if check_response:
         return _response_json(response)
     return response.json()
 
 
-def _post_request_with_files(headers, url, data, files, check_response=True, retry_codes=None):
-    session = _retrying_session(headers=headers, retry_codes=retry_codes)
-    response = session.post(url, data, files=files, timeout=REQUEST_TIMEOUT)
-    if check_response:
-        return _response_json(response)
-    return response.json()
+def _post_request_with_files(
+    headers,
+    url,
+    data,
+    files,
+    check_response=True,
+    user_agent=None,
+):
+    session = _single_attempt_session(headers=headers, user_agent=user_agent)
+    try:
+        response = session.post(url, data, files=files, timeout=REQUEST_TIMEOUT)
+    except requests.RequestException as exc:
+        raise SplunkbaseAmbiguousUpload(
+            f"Splunkbase upload transport failed after one counted attempt: {exc}"
+        ) from exc
+
+    _log_response_metadata(response)
+    request_id = _request_id(response)
+    if response.status_code == 429:
+        raise SplunkbaseRateLimited(
+            "Splunkbase upload rate limit reached after one counted attempt",
+            status_code=response.status_code,
+            retry_after=response.headers.get("Retry-After"),
+            request_id=request_id,
+        )
+    if response.status_code in (401, 403):
+        raise SplunkbasePermissionDenied(
+            "Splunkbase publishing identity is not permitted to upload this connector",
+            status_code=response.status_code,
+            request_id=request_id,
+        )
+    if response.status_code >= 500:
+        raise SplunkbaseAmbiguousUpload(
+            "Splunkbase returned a server error after one counted attempt",
+            status_code=response.status_code,
+            request_id=request_id,
+        )
+    if not response.ok:
+        raise SplunkbaseValidationFailed(
+            f"Splunkbase rejected the upload: HTTP {response.status_code}: {response.text}",
+            status_code=response.status_code,
+            request_id=request_id,
+        )
+
+    try:
+        return _response_json(response) if check_response else response.json()
+    except SplunkbaseResponseError as exc:
+        raise SplunkbaseAmbiguousUpload(
+            "Splunkbase returned an unreadable response after one counted attempt",
+            status_code=response.status_code,
+            request_id=request_id,
+        ) from exc
 
 
 @backoff.on_exception(backoff.expo, SplunkbaseResponseError, max_time=MAX_MESSAGE_RETRY_TIME)
@@ -115,12 +257,13 @@ def _get_request(url, return_json=True, params=None, headers=None, auth=None, re
 
 
 class Splunkbase:
-    def __init__(self, splunkbase_user, splunkbase_password):
+    def __init__(self, splunkbase_user, splunkbase_password, request_context=None):
         self.env = "PROD"
         self._apps_base_url = SPLUNKBASE_BASE_URL
         self._splunkbase_editor_url = SPLUNKBASE_EDITOR_URL
         self.splunkbase_user = splunkbase_user
         self.splunkbase_password = splunkbase_password
+        self.user_agent = build_user_agent(**(request_context or {}))
         self.auth = self._get_bearer_auth()
 
     def _get_bearer_auth(self) -> Optional[dict[str, str]]:
@@ -148,7 +291,6 @@ class Splunkbase:
             response = response.get("message")
         return response in RESPONSE_MESSAGES_TO_RETRY
 
-    @backoff.on_predicate(backoff.expo, _is_retryable_response, max_time=MAX_MESSAGE_RETRY_TIME)
     def _upload(self, app_repo_name, package_file, url, release_notes, license_string, license_url):
         if not self.auth:
             raise ValueError("Authentication must be configured for POST requests")
@@ -166,11 +308,22 @@ class Splunkbase:
         with open(package_file, "rb") as file:
             logging.info("About to post request with url: %s", url)
             response = _post_request_with_files(
-                self.auth, url, data, {"package_file": file}, True, STATUS_CODES_TO_RETRY
+                self.auth,
+                url,
+                data,
+                {"package_file": file},
+                True,
+                user_agent=self.user_agent,
             )
             if response.get("message", "") in SPLUNKBASE_SUCCESSFUL_UPLOAD_RESPONSES:
                 return response.get("package_id")
-            return response
+            if self._is_retryable_response(response):
+                raise SplunkbaseAmbiguousUpload(
+                    "Splunkbase reported an ambiguous upload result after one counted attempt"
+                )
+            raise SplunkbaseValidationFailed(
+                f"Splunkbase rejected the upload: {response.get('message', response)}"
+            )
 
     @property
     def apps_base_url(self):

--- a/.github/utils/api/splunkbase.py
+++ b/.github/utils/api/splunkbase.py
@@ -452,14 +452,47 @@ class Splunkbase:
 
         return apps_returned[-1]["releases"]
 
-    def add_app_editor(self, sb_appid):
+    def get_app_editors(self, sb_appid):
+        editor_url = self._splunkbase_editor_url.replace("{sb_appid}", str(sb_appid))
+        response = _get_request(editor_url, headers=self.auth)
+        if isinstance(response, dict):
+            editors = next(
+                (
+                    response[key]
+                    for key in ("results", "editors", "data")
+                    if isinstance(response.get(key), list)
+                ),
+                [],
+            )
+        elif isinstance(response, list):
+            editors = response
+        else:
+            raise SplunkbaseResponseError("Splunkbase returned malformed editor metadata")
+
+        normalized = set()
+        for editor in editors:
+            if isinstance(editor, str):
+                normalized.add(editor)
+            elif isinstance(editor, dict):
+                username = editor.get("username") or editor.get("name") or editor.get("user")
+                if username:
+                    normalized.add(str(username))
+        return normalized
+
+    def ensure_app_editors(self, sb_appid):
         if not self.auth:
             raise ValueError("Authentication must be configured for POST requests")
 
-        for user in SPLUNKBASE_SOAR_APP_EDITORS:
+        existing_editors = self.get_app_editors(sb_appid)
+        for user in set(SPLUNKBASE_SOAR_APP_EDITORS) - existing_editors:
             data = {"username": user}
             editor_url = self._splunkbase_editor_url.replace("{sb_appid}", str(sb_appid))
             logging.info(editor_url)
             logging.info(f"Adding editor {user} to splunkbase appid {sb_appid}")
             response = _post_request(self.auth, editor_url, data=data)
             logging.info(response)
+
+    def add_app_editor(self, sb_appid):
+        """Backward-compatible wrapper for idempotent editor reconciliation."""
+
+        self.ensure_app_editors(sb_appid)

--- a/.github/utils/api/splunkbase.py
+++ b/.github/utils/api/splunkbase.py
@@ -76,6 +76,12 @@ class SplunkbaseValidationFailed(SplunkbaseUploadError):
     """Raised when Splunkbase definitively rejects the submitted package."""
 
 
+def _is_retryable_status_response(response):
+    if isinstance(response, dict):
+        response = response.get("message")
+    return response in RESPONSE_MESSAGES_TO_RETRY
+
+
 def build_user_agent(repo=None, version=None, run_id=None, run_attempt=None):
     """Return a stable, non-secret User-Agent with release correlation fields."""
 
@@ -236,13 +242,16 @@ def _post_request_with_files(
         )
 
     try:
-        return _response_json(response) if check_response else response.json()
+        data = _response_json(response) if check_response else response.json()
     except SplunkbaseResponseError as exc:
         raise SplunkbaseAmbiguousUpload(
             "Splunkbase returned an unreadable response after one counted attempt",
             status_code=response.status_code,
             request_id=request_id,
         ) from exc
+    if isinstance(data, dict) and request_id:
+        data["_request_id"] = request_id
+    return data
 
 
 @backoff.on_exception(backoff.expo, SplunkbaseResponseError, max_time=MAX_MESSAGE_RETRY_TIME)
@@ -286,10 +295,26 @@ class Splunkbase:
 
         return {"Authorization": f"Bearer {token}"}
 
+    @staticmethod
     def _is_retryable_response(response):
-        if isinstance(response, dict):
-            response = response.get("message")
-        return response in RESPONSE_MESSAGES_TO_RETRY
+        return _is_retryable_status_response(response)
+
+    @staticmethod
+    def is_definitive_validation_failure(response):
+        if not isinstance(response, dict):
+            return False
+        if any(response.get(key) for key in ("error", "errors", "validation_errors")):
+            return True
+        status_text = " ".join(str(response.get(key, "")) for key in ("status", "message")).lower()
+        return any(
+            marker in status_text
+            for marker in (
+                "failed validation",
+                "validation failed",
+                "rejected",
+                "invalid package",
+            )
+        )
 
     def _upload(self, app_repo_name, package_file, url, release_notes, license_string, license_url):
         if not self.auth:
@@ -316,6 +341,7 @@ class Splunkbase:
                 user_agent=self.user_agent,
             )
             if response.get("message", "") in SPLUNKBASE_SUCCESSFUL_UPLOAD_RESPONSES:
+                self.last_upload_request_id = response.get("_request_id")
                 return response.get("package_id")
             if self._is_retryable_response(response):
                 raise SplunkbaseAmbiguousUpload(
@@ -343,7 +369,11 @@ class Splunkbase:
             app_repo_name, package_file, url, release_notes, license_string, license_url
         )
 
-    @backoff.on_predicate(backoff.expo, _is_retryable_response, max_time=MAX_MESSAGE_RETRY_TIME)
+    @backoff.on_predicate(
+        backoff.expo,
+        _is_retryable_status_response,
+        max_time=MAX_MESSAGE_RETRY_TIME,
+    )
     def check_upload_status(self, package_id):
         url = f"{self.apps_base_url}/validation/{package_id}"
         return _get_request(url, headers=self.auth)

--- a/.github/utils/api/test_splunkbase.py
+++ b/.github/utils/api/test_splunkbase.py
@@ -5,6 +5,7 @@ import requests
 
 from .splunkbase import (
     READ_REQUEST_NUM_RETRIES,
+    Splunkbase,
     SplunkbaseAmbiguousUpload,
     SplunkbasePermissionDenied,
     SplunkbaseRateLimited,
@@ -94,6 +95,32 @@ def test_rate_limit_preserves_retry_after_and_request_id():
     assert error.value.request_id == "request-123"
 
 
+def test_successful_upload_response_preserves_request_id():
+    session = Mock()
+    session.post.return_value = _response(
+        201,
+        data={
+            "message": "Release was successfully uploaded and is being validated.",
+            "package_id": "package-123",
+        },
+        headers={"X-Request-ID": "request-123"},
+    )
+
+    with patch(
+        "utils.api.splunkbase._single_attempt_session",
+        return_value=session,
+    ):
+        result = _post_request_with_files(
+            {},
+            "https://example.test/upload",
+            {},
+            {"package": Mock()},
+        )
+
+    assert result["package_id"] == "package-123"
+    assert result["_request_id"] == "request-123"
+
+
 @pytest.mark.parametrize("transport_error", [requests.ConnectionError(), requests.Timeout()])
 def test_transport_failure_makes_exactly_one_post(transport_error):
     session = Mock()
@@ -122,6 +149,12 @@ def test_user_agent_adds_only_non_secret_correlation():
     assert "version/1.2.3" in user_agent
     assert "run/123" in user_agent
     assert "attempt/2" in user_agent
+
+
+def test_retryable_response_helper_can_be_called_on_an_instance():
+    client = object.__new__(Splunkbase)
+
+    assert client._is_retryable_response({"message": "Package validation still in progress."})
 
 
 def test_response_json_rejects_missing_collection_fields():

--- a/.github/utils/api/test_splunkbase.py
+++ b/.github/utils/api/test_splunkbase.py
@@ -1,25 +1,127 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
+import requests
 
 from .splunkbase import (
-    POST_WITH_FILES_NUM_RETRIES,
+    READ_REQUEST_NUM_RETRIES,
+    SplunkbaseAmbiguousUpload,
+    SplunkbasePermissionDenied,
+    SplunkbaseRateLimited,
     SplunkbaseResponseError,
+    SplunkbaseValidationFailed,
     USER_AGENT,
+    _post_request_with_files,
     _response_json,
     _retrying_session,
+    _single_attempt_session,
+    build_user_agent,
 )
 
 
-def test_retrying_session_retries_transient_gets_and_posts():
+def test_retrying_session_only_retries_read_only_gets():
     session = _retrying_session()
     retry = session.get_adapter("https://").max_retries
 
     assert session.headers["User-Agent"] == USER_AGENT
-    assert retry.total == POST_WITH_FILES_NUM_RETRIES
-    assert retry.allowed_methods == frozenset(["GET", "POST"])
-    assert {403, 429, 500, 502, 503, 504} <= set(retry.status_forcelist)
+    assert retry.total == READ_REQUEST_NUM_RETRIES
+    assert retry.allowed_methods == frozenset(["GET"])
+    assert {429, 500, 502, 503, 504} <= set(retry.status_forcelist)
+    assert 403 not in retry.status_forcelist
     assert retry.respect_retry_after_header is True
+
+
+def test_upload_session_has_no_automatic_retries():
+    session = _single_attempt_session(user_agent="queue-test")
+    retry = session.get_adapter("https://").max_retries
+
+    assert session.headers["User-Agent"] == "queue-test"
+    assert retry.total == 0
+    assert retry.connect == 0
+    assert retry.read == 0
+    assert retry.status == 0
+
+
+def _response(status_code, *, data=None, text="", headers=None):
+    response = Mock()
+    response.status_code = status_code
+    response.ok = 200 <= status_code < 400
+    response.text = text
+    response.headers = headers or {}
+    response.json.return_value = data or {}
+    return response
+
+
+@pytest.mark.parametrize(
+    ("response", "error_type"),
+    [
+        (_response(401), SplunkbasePermissionDenied),
+        (_response(403), SplunkbasePermissionDenied),
+        (_response(429, headers={"Retry-After": "300"}), SplunkbaseRateLimited),
+        (_response(503), SplunkbaseAmbiguousUpload),
+        (_response(422, text="invalid package"), SplunkbaseValidationFailed),
+    ],
+)
+def test_upload_failure_makes_exactly_one_post(response, error_type):
+    session = Mock()
+    session.post.return_value = response
+
+    with patch(
+        "utils.api.splunkbase._single_attempt_session",
+        return_value=session,
+    ):
+        with pytest.raises(error_type):
+            _post_request_with_files({}, "https://example.test/upload", {}, {"package": Mock()})
+
+    session.post.assert_called_once()
+
+
+def test_rate_limit_preserves_retry_after_and_request_id():
+    session = Mock()
+    session.post.return_value = _response(
+        429,
+        headers={"Retry-After": "300", "X-Request-ID": "request-123"},
+    )
+
+    with patch(
+        "utils.api.splunkbase._single_attempt_session",
+        return_value=session,
+    ):
+        with pytest.raises(SplunkbaseRateLimited) as error:
+            _post_request_with_files({}, "https://example.test/upload", {}, {"package": Mock()})
+
+    assert error.value.retry_after == "300"
+    assert error.value.request_id == "request-123"
+
+
+@pytest.mark.parametrize("transport_error", [requests.ConnectionError(), requests.Timeout()])
+def test_transport_failure_makes_exactly_one_post(transport_error):
+    session = Mock()
+    session.post.side_effect = transport_error
+
+    with patch(
+        "utils.api.splunkbase._single_attempt_session",
+        return_value=session,
+    ):
+        with pytest.raises(SplunkbaseAmbiguousUpload):
+            _post_request_with_files({}, "https://example.test/upload", {}, {"package": Mock()})
+
+    session.post.assert_called_once()
+
+
+def test_user_agent_adds_only_non_secret_correlation():
+    user_agent = build_user_agent(
+        repo="crowdsec",
+        version="1.2.3",
+        run_id="123",
+        run_attempt="2",
+    )
+
+    assert user_agent.startswith(USER_AGENT)
+    assert "repo/crowdsec" in user_agent
+    assert "version/1.2.3" in user_agent
+    assert "run/123" in user_agent
+    assert "attempt/2" in user_agent
 
 
 def test_response_json_rejects_missing_collection_fields():

--- a/.github/utils/api/test_splunkbase.py
+++ b/.github/utils/api/test_splunkbase.py
@@ -157,6 +157,27 @@ def test_retryable_response_helper_can_be_called_on_an_instance():
     assert client._is_retryable_response({"message": "Package validation still in progress."})
 
 
+def test_editor_reconciliation_adds_only_missing_editors():
+    client = object.__new__(Splunkbase)
+    client.auth = {"Authorization": "Bearer token"}
+    client._splunkbase_editor_url = "https://example.test/app/{sb_appid}/editors/"
+
+    with (
+        patch(
+            "utils.api.splunkbase._get_request",
+            return_value={"editors": [{"username": "nastor_splunk"}]},
+        ),
+        patch("utils.api.splunkbase._post_request", return_value={"ok": True}) as post,
+    ):
+        client.ensure_app_editors("app-123")
+
+    post.assert_called_once_with(
+        client.auth,
+        "https://example.test/app/app-123/editors/",
+        data={"username": "coh_splunk"},
+    )
+
+
 def test_response_json_rejects_missing_collection_fields():
     response = Mock(ok=True)
     response.json.return_value = {"detail": "temporarily unavailable"}

--- a/.github/utils/publish_queue.py
+++ b/.github/utils/publish_queue.py
@@ -39,6 +39,7 @@ LABELS = {
     STATE_LABEL: ("c5def5", "Rate ledger for the Codex-authored Splunkbase queue."),
 }
 PUBLIC_RESULT_FIELDS = {
+    "app_existed_before_upload",
     "status",
     "status_code",
     "request_id",
@@ -121,6 +122,14 @@ class PublishQueue(Protocol):
         reason: str,
         *,
         rate_limited: bool = False,
+    ) -> None: ...
+
+    def verify(
+        self,
+        item: PublishQueueItem,
+        result: dict[str, Any],
+        not_before: datetime,
+        reason: str,
     ) -> None: ...
 
     def complete(self, item: PublishQueueItem, result: dict[str, Any]) -> None: ...

--- a/.github/utils/publish_queue.py
+++ b/.github/utils/publish_queue.py
@@ -99,6 +99,7 @@ class PublishQueueItem:
 class PublishAttempt:
     started_at: str
     outcome: str
+    app_existed_before_upload: bool
     status_code: int | None = None
     request_id: str | None = None
     retry_after: str | None = None

--- a/.github/utils/publish_queue.py
+++ b/.github/utils/publish_queue.py
@@ -14,6 +14,7 @@ QUEUE_MARKER = "splunkbase-publish"
 QUEUE_STATES = {
     "queued": "splunkbase-queued",
     "active": "splunkbase-active",
+    "verifying": "splunkbase-verifying",
     "rate_limited": "splunkbase-rate-limited",
     "blocked": "splunkbase-blocked",
     "published": "splunkbase-published",
@@ -28,6 +29,10 @@ LABELS = {
     QUEUE_MARKER: ("5319e7", "Managed by Codex-authored Splunkbase queue automation."),
     QUEUE_STATES["queued"]: ("fbca04", "Waiting for the shared Splunkbase publishing user."),
     QUEUE_STATES["active"]: ("1d76db", "A Codex-authored worker is processing this publication."),
+    QUEUE_STATES["verifying"]: (
+        "bfd4f2",
+        "Splunkbase accepted the upload; only GET reconciliation is permitted.",
+    ),
     QUEUE_STATES["rate_limited"]: ("d93f0b", "Splunkbase asked the shared user to wait."),
     QUEUE_STATES["blocked"]: ("b60205", "Publication needs human intervention."),
     QUEUE_STATES["published"]: ("0e8a16", "The connector version is present on Splunkbase."),
@@ -74,6 +79,7 @@ class PublishQueueItem:
     schema_version: int = 1
     issue_number: int | None = None
     attempts: list[dict[str, Any]] = field(default_factory=list)
+    verification: dict[str, Any] | None = None
 
     @property
     def dedupe_key(self) -> str:
@@ -255,7 +261,11 @@ class GitHubIssuePublishQueue:
             labels = self._label_names(issue)
             if QUEUE_STATES["published"] in labels:
                 return existing_item
-            if QUEUE_STATES["blocked"] in labels or QUEUE_STATES["active"] in labels:
+            if (
+                QUEUE_STATES["blocked"] in labels
+                or QUEUE_STATES["active"] in labels
+                or QUEUE_STATES["verifying"] in labels
+            ):
                 return existing_item
 
             item.issue_number = issue["number"]
@@ -295,7 +305,11 @@ class GitHubIssuePublishQueue:
         candidates = []
         for issue in self._issues(state="open", labels=QUEUE_MARKER):
             labels = self._label_names(issue)
-            if not (QUEUE_STATES["queued"] in labels or QUEUE_STATES["active"] in labels):
+            if not (
+                QUEUE_STATES["queued"] in labels
+                or QUEUE_STATES["active"] in labels
+                or QUEUE_STATES["verifying"] in labels
+            ):
                 continue
             try:
                 item = _decode_body(issue.get("body") or "")
@@ -370,6 +384,22 @@ class GitHubIssuePublishQueue:
             note=reason,
             extra_labels=extra_labels,
         )
+
+    def verify(
+        self,
+        item: PublishQueueItem,
+        result: dict[str, Any],
+        not_before: datetime,
+        reason: str,
+    ) -> None:
+        public_result = _public_result(result)
+        item.verification = public_result
+        item.not_before = format_datetime(not_before)
+        if item.attempts:
+            item.attempts[-1].update(public_result)
+        else:
+            item.attempts.append(public_result)
+        self._update(item, state="verifying", note=reason)
 
     def complete(self, item: PublishQueueItem, result: dict[str, Any]) -> None:
         public_result = _public_result(result)

--- a/.github/utils/publish_queue.py
+++ b/.github/utils/publish_queue.py
@@ -1,0 +1,493 @@
+"""Durable GitHub-issue storage for serialized Splunkbase uploads."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+import json
+from typing import Any, Protocol
+
+import requests
+
+
+QUEUE_MARKER = "splunkbase-publish"
+QUEUE_STATES = {
+    "queued": "splunkbase-queued",
+    "active": "splunkbase-active",
+    "rate_limited": "splunkbase-rate-limited",
+    "blocked": "splunkbase-blocked",
+    "published": "splunkbase-published",
+}
+STATE_LABEL = "splunkbase-publish-state"
+BODY_START = "<!-- splunkbase-publish-queue-json"
+BODY_END = "splunkbase-publish-queue-json -->"
+MAX_ATTEMPTS_PER_HOUR = 12
+MIN_ATTEMPT_INTERVAL = timedelta(minutes=5)
+
+LABELS = {
+    QUEUE_MARKER: ("5319e7", "Managed by Codex-authored Splunkbase queue automation."),
+    QUEUE_STATES["queued"]: ("fbca04", "Waiting for the shared Splunkbase publishing user."),
+    QUEUE_STATES["active"]: ("1d76db", "A Codex-authored worker is processing this publication."),
+    QUEUE_STATES["rate_limited"]: ("d93f0b", "Splunkbase asked the shared user to wait."),
+    QUEUE_STATES["blocked"]: ("b60205", "Publication needs human intervention."),
+    QUEUE_STATES["published"]: ("0e8a16", "The connector version is present on Splunkbase."),
+    STATE_LABEL: ("c5def5", "Rate ledger for the Codex-authored Splunkbase queue."),
+}
+PUBLIC_RESULT_FIELDS = {
+    "status",
+    "status_code",
+    "request_id",
+    "retry_after",
+    "release_version",
+    "package_id",
+    "splunkbase_app_id",
+}
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def parse_datetime(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def format_datetime(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@dataclass
+class PublishQueueItem:
+    publisher_alias: str
+    repository: str
+    run_id: int
+    run_attempt: int
+    commit_sha: str
+    artifact_name: str
+    asset_name: str
+    release_tag: str
+    candidate_version: str
+    appid: str
+    app_name: str
+    enqueued_at: str
+    not_before: str
+    schema_version: int = 1
+    issue_number: int | None = None
+    attempts: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def dedupe_key(self) -> str:
+        return f"{self.publisher_alias}:{self.repository}:{self.candidate_version}"
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PublishQueueItem:
+        allowed = set(cls.__dataclass_fields__)
+        return cls(**{key: value for key, value in data.items() if key in allowed})
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class PublishAttempt:
+    started_at: str
+    outcome: str
+    status_code: int | None = None
+    request_id: str | None = None
+    retry_after: str | None = None
+
+
+class PublishQueue(Protocol):
+    def enqueue(self, item: PublishQueueItem) -> PublishQueueItem: ...
+
+    def oldest_eligible(
+        self,
+        publisher_alias: str,
+        now: datetime,
+    ) -> PublishQueueItem | None: ...
+
+    def record_attempt(self, item: PublishQueueItem, attempt: PublishAttempt) -> None: ...
+
+    def requeue(
+        self,
+        item: PublishQueueItem,
+        not_before: datetime,
+        reason: str,
+        *,
+        rate_limited: bool = False,
+    ) -> None: ...
+
+    def complete(self, item: PublishQueueItem, result: dict[str, Any]) -> None: ...
+
+    def block(self, item: PublishQueueItem, result: dict[str, Any]) -> None: ...
+
+
+class GitHubClient:
+    def __init__(self, token: str, api_url: str = "https://api.github.com"):
+        self.api_url = api_url.rstrip("/")
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "Splunk-SOAR-Publish-Queue/1.0 (Codex-authored)",
+            }
+        )
+
+    def request(self, method: str, path: str, **kwargs):
+        response = self.session.request(
+            method,
+            f"{self.api_url}/{path.lstrip('/')}",
+            timeout=(10, 60),
+            **kwargs,
+        )
+        if not response.ok:
+            raise RuntimeError(
+                f"GitHub API {method} {path} failed: {response.status_code}: {response.text}"
+            )
+        if response.status_code == 204 or not response.content:
+            return None
+        return response.json()
+
+    def download(self, path: str, destination) -> None:
+        response = self.session.get(
+            f"{self.api_url}/{path.lstrip('/')}",
+            headers={"Accept": "application/octet-stream"},
+            timeout=(10, 120),
+            stream=True,
+        )
+        if not response.ok:
+            raise RuntimeError(
+                f"GitHub API GET {path} failed: {response.status_code}: {response.text}"
+            )
+        with open(destination, "wb") as output:
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                output.write(chunk)
+
+
+def _encode_body(item: PublishQueueItem, note: str | None = None) -> str:
+    note_text = f"\n\nStatus note: {note}" if note else ""
+    return (
+        "Created and managed by Codex-authored Splunkbase queue automation."
+        f"{note_text}\n\n{BODY_START}\n"
+        f"{json.dumps(item.as_dict(), indent=2, sort_keys=True)}\n"
+        f"{BODY_END}\n"
+    )
+
+
+def _decode_body(body: str) -> PublishQueueItem:
+    start = body.index(BODY_START) + len(BODY_START)
+    end = body.index(BODY_END, start)
+    return PublishQueueItem.from_dict(json.loads(body[start:end].strip()))
+
+
+def _public_result(result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in result.items()
+        if key in PUBLIC_RESULT_FIELDS and value is not None
+    }
+
+
+class GitHubIssuePublishQueue:
+    def __init__(self, client: GitHubClient, repository: str):
+        self.client = client
+        self.repository = repository
+        self.repo_path = f"repos/{repository}"
+
+    def ensure_labels(self) -> None:
+        existing = {
+            label["name"]
+            for label in self.client.request(
+                "GET",
+                f"{self.repo_path}/labels",
+                params={"per_page": 100},
+            )
+        }
+        for name, (color, description) in LABELS.items():
+            if name not in existing:
+                self.client.request(
+                    "POST",
+                    f"{self.repo_path}/labels",
+                    json={"name": name, "color": color, "description": description},
+                )
+
+    def _issues(self, *, state: str = "open", labels: str = QUEUE_MARKER):
+        page = 1
+        while True:
+            issues = self.client.request(
+                "GET",
+                f"{self.repo_path}/issues",
+                params={
+                    "state": state,
+                    "labels": labels,
+                    "per_page": 100,
+                    "page": page,
+                },
+            )
+            for issue in issues:
+                if "pull_request" not in issue:
+                    yield issue
+            if len(issues) < 100:
+                return
+            page += 1
+
+    @staticmethod
+    def _label_names(issue: dict[str, Any]) -> set[str]:
+        return {label["name"] for label in issue.get("labels", [])}
+
+    def _find_dedupe(self, dedupe_key: str):
+        for issue in self._issues(state="all"):
+            try:
+                item = _decode_body(issue.get("body") or "")
+            except (ValueError, KeyError, TypeError, json.JSONDecodeError):
+                continue
+            if item.dedupe_key == dedupe_key:
+                return issue, item
+        return None, None
+
+    def enqueue(self, item: PublishQueueItem) -> PublishQueueItem:
+        self.ensure_labels()
+        issue, existing_item = self._find_dedupe(item.dedupe_key)
+        if issue:
+            existing_item.issue_number = issue["number"]
+            labels = self._label_names(issue)
+            if QUEUE_STATES["published"] in labels:
+                return existing_item
+            if QUEUE_STATES["blocked"] in labels or QUEUE_STATES["active"] in labels:
+                return existing_item
+
+            item.issue_number = issue["number"]
+            self.client.request(
+                "PATCH",
+                f"{self.repo_path}/issues/{issue['number']}",
+                json={
+                    "body": _encode_body(item, "Duplicate enqueue updated the immutable asset."),
+                    "state": "open",
+                    "labels": [QUEUE_MARKER, QUEUE_STATES["queued"]],
+                },
+            )
+            return item
+
+        created = self.client.request(
+            "POST",
+            f"{self.repo_path}/issues",
+            json={
+                "title": (f"[Splunkbase queue] {item.repository} v{item.candidate_version}"),
+                "body": _encode_body(item),
+                "labels": [QUEUE_MARKER, QUEUE_STATES["queued"]],
+            },
+        )
+        item.issue_number = created["number"]
+        self.client.request(
+            "PATCH",
+            f"{self.repo_path}/issues/{created['number']}",
+            json={"body": _encode_body(item)},
+        )
+        return item
+
+    def oldest_eligible(
+        self,
+        publisher_alias: str,
+        now: datetime,
+    ) -> PublishQueueItem | None:
+        candidates = []
+        for issue in self._issues(state="open", labels=QUEUE_MARKER):
+            labels = self._label_names(issue)
+            if not (QUEUE_STATES["queued"] in labels or QUEUE_STATES["active"] in labels):
+                continue
+            try:
+                item = _decode_body(issue.get("body") or "")
+            except (ValueError, KeyError, TypeError, json.JSONDecodeError):
+                continue
+            if item.publisher_alias != publisher_alias:
+                continue
+            if parse_datetime(item.not_before) > now:
+                continue
+            item.issue_number = issue["number"]
+            candidates.append(item)
+        if not candidates:
+            return None
+        return min(candidates, key=lambda candidate: parse_datetime(candidate.enqueued_at))
+
+    def get_item(self, issue_number: int) -> PublishQueueItem:
+        issue = self.client.request(
+            "GET",
+            f"{self.repo_path}/issues/{issue_number}",
+        )
+        item = _decode_body(issue.get("body") or "")
+        item.issue_number = issue_number
+        return item
+
+    def _update(
+        self,
+        item: PublishQueueItem,
+        *,
+        state: str,
+        note: str,
+        close: bool = False,
+        extra_labels: list[str] | None = None,
+    ) -> None:
+        if item.issue_number is None:
+            raise ValueError("Queue item has no GitHub issue number")
+        labels = [QUEUE_MARKER, QUEUE_STATES[state], *(extra_labels or [])]
+        self.client.request(
+            "PATCH",
+            f"{self.repo_path}/issues/{item.issue_number}",
+            json={
+                "body": _encode_body(item, note),
+                "labels": labels,
+                "state": "closed" if close else "open",
+            },
+        )
+
+    def activate(self, item: PublishQueueItem, lease_until: datetime) -> None:
+        item.not_before = format_datetime(lease_until)
+        self._update(item, state="active", note="Selected by the central publisher.")
+
+    def record_attempt(self, item: PublishQueueItem, attempt: PublishAttempt) -> None:
+        item.attempts.append(asdict(attempt))
+        self._update(
+            item,
+            state="active",
+            note=f"Counted upload attempt started at {attempt.started_at}.",
+        )
+
+    def requeue(
+        self,
+        item: PublishQueueItem,
+        not_before: datetime,
+        reason: str,
+        *,
+        rate_limited: bool = False,
+    ) -> None:
+        item.not_before = format_datetime(not_before)
+        extra_labels = [QUEUE_STATES["rate_limited"]] if rate_limited else []
+        self._update(
+            item,
+            state="queued",
+            note=reason,
+            extra_labels=extra_labels,
+        )
+
+    def complete(self, item: PublishQueueItem, result: dict[str, Any]) -> None:
+        public_result = _public_result(result)
+        if item.attempts:
+            item.attempts[-1].update(public_result)
+        else:
+            item.attempts.append(public_result)
+        self._update(
+            item,
+            state="published",
+            note="The candidate version is present on Splunkbase.",
+            close=True,
+        )
+
+    def block(self, item: PublishQueueItem, result: dict[str, Any]) -> None:
+        public_result = _public_result(result)
+        if item.attempts:
+            item.attempts[-1].update(public_result)
+        else:
+            item.attempts.append(public_result)
+        self._update(
+            item,
+            state="blocked",
+            note="Publication stopped without an automatic retry; inspect the worker log.",
+        )
+
+    def _state_issue(self, publisher_alias: str):
+        title = f"[Splunkbase queue state] {publisher_alias}"
+        for issue in self._issues(state="open", labels=STATE_LABEL):
+            if issue["title"] == title:
+                return issue
+        return self.client.request(
+            "POST",
+            f"{self.repo_path}/issues",
+            json={
+                "title": title,
+                "body": (
+                    "Managed by Codex-authored Splunkbase queue automation.\n\n"
+                    f"{BODY_START}\n"
+                    f"{json.dumps({'publisher_alias': publisher_alias, 'attempts': []}, indent=2)}\n"
+                    f"{BODY_END}\n"
+                ),
+                "labels": [STATE_LABEL],
+            },
+        )
+
+    def reserve_attempt(
+        self,
+        publisher_alias: str,
+        item: PublishQueueItem,
+        now: datetime,
+    ) -> datetime | None:
+        issue = self._state_issue(publisher_alias)
+        body = issue.get("body") or ""
+        start = body.index(BODY_START) + len(BODY_START)
+        end = body.index(BODY_END, start)
+        state = json.loads(body[start:end].strip())
+        cutoff = now - timedelta(hours=1)
+        attempts = [
+            attempt
+            for attempt in state.get("attempts", [])
+            if parse_datetime(attempt["started_at"]) > cutoff
+        ]
+
+        retry_at = None
+        if attempts:
+            last_attempt = max(parse_datetime(attempt["started_at"]) for attempt in attempts)
+            retry_at = last_attempt + MIN_ATTEMPT_INTERVAL
+        if len(attempts) >= MAX_ATTEMPTS_PER_HOUR:
+            hourly_retry = min(parse_datetime(attempt["started_at"]) for attempt in attempts)
+            hourly_retry += timedelta(hours=1)
+            retry_at = max(retry_at or hourly_retry, hourly_retry)
+        if retry_at and retry_at > now:
+            return retry_at
+
+        attempts.append(
+            {
+                "issue_number": item.issue_number,
+                "repository": item.repository,
+                "version": item.candidate_version,
+                "started_at": format_datetime(now),
+            }
+        )
+        state["attempts"] = attempts
+        state_body = (
+            "Managed by Codex-authored Splunkbase queue automation.\n\n"
+            f"{BODY_START}\n{json.dumps(state, indent=2, sort_keys=True)}\n{BODY_END}\n"
+        )
+        self.client.request(
+            "PATCH",
+            f"{self.repo_path}/issues/{issue['number']}",
+            json={"body": state_body},
+        )
+        return None
+
+    def delete_asset(self, item: PublishQueueItem) -> None:
+        release = self.client.request(
+            "GET",
+            f"{self.repo_path}/releases/tags/{item.release_tag}",
+        )
+        for asset in release.get("assets", []):
+            if asset["name"] == item.asset_name:
+                self.client.request(
+                    "DELETE",
+                    f"{self.repo_path}/releases/assets/{asset['id']}",
+                )
+                return
+
+    def download_asset(self, item: PublishQueueItem, destination) -> None:
+        release = self.client.request(
+            "GET",
+            f"{self.repo_path}/releases/tags/{item.release_tag}",
+        )
+        for asset in release.get("assets", []):
+            if asset["name"] == item.asset_name:
+                self.client.download(
+                    f"{self.repo_path}/releases/assets/{asset['id']}",
+                    destination,
+                )
+                return
+        raise RuntimeError(f"Queue asset {item.asset_name} was not found")

--- a/.github/utils/test_publish_queue.py
+++ b/.github/utils/test_publish_queue.py
@@ -1,0 +1,213 @@
+from datetime import datetime, timedelta, timezone
+import json
+
+from .publish_queue import (
+    BODY_END,
+    BODY_START,
+    LABELS,
+    MAX_ATTEMPTS_PER_HOUR,
+    MIN_ATTEMPT_INTERVAL,
+    GitHubIssuePublishQueue,
+    PublishQueueItem,
+    _decode_body,
+    _encode_body,
+    format_datetime,
+)
+
+
+def make_item(**overrides):
+    now = "2026-07-29T12:00:00Z"
+    values = {
+        "publisher_alias": "soar-connectors-default",
+        "repository": "splunk-soar-connectors/example",
+        "run_id": 123,
+        "run_attempt": 1,
+        "commit_sha": "abc123",
+        "artifact_name": "app-tar",
+        "asset_name": "example-1.2.3.tgz",
+        "release_tag": "splunkbase-publish-queue",
+        "candidate_version": "1.2.3",
+        "appid": "example-guid",
+        "app_name": "Example",
+        "enqueued_at": now,
+        "not_before": now,
+    }
+    values.update(overrides)
+    return PublishQueueItem(**values)
+
+
+class FakeGitHubClient:
+    def __init__(self):
+        self.labels = set(LABELS)
+        self.issues = []
+        self.next_issue = 1
+
+    def request(self, method, path, **kwargs):
+        if path.endswith("/labels") and method == "GET":
+            return [{"name": label} for label in self.labels]
+        if path.endswith("/labels") and method == "POST":
+            self.labels.add(kwargs["json"]["name"])
+            return kwargs["json"]
+        if path.endswith("/issues") and method == "GET":
+            params = kwargs.get("params", {})
+            requested_labels = set(filter(None, params.get("labels", "").split(",")))
+            state = params.get("state", "open")
+            matching = []
+            for issue in self.issues:
+                if state != "all" and issue["state"] != state:
+                    continue
+                issue_labels = {label["name"] for label in issue["labels"]}
+                if requested_labels <= issue_labels:
+                    matching.append(issue.copy())
+            return matching
+        if path.endswith("/issues") and method == "POST":
+            data = kwargs["json"]
+            issue = {
+                "number": self.next_issue,
+                "title": data["title"],
+                "body": data["body"],
+                "state": data.get("state", "open"),
+                "labels": [{"name": label} for label in data.get("labels", [])],
+            }
+            self.next_issue += 1
+            self.issues.append(issue)
+            return issue.copy()
+
+        issue_number = int(path.rsplit("/", 1)[-1])
+        issue = next(issue for issue in self.issues if issue["number"] == issue_number)
+        if method == "GET":
+            return issue.copy()
+        if method == "PATCH":
+            data = kwargs["json"]
+            issue.update({key: value for key, value in data.items() if key != "labels"})
+            if "labels" in data:
+                issue["labels"] = [{"name": label} for label in data["labels"]]
+            return issue.copy()
+        raise AssertionError(f"Unhandled request: {method} {path}")
+
+
+def test_queue_body_round_trip_preserves_dedupe_fields():
+    item = make_item()
+
+    decoded = _decode_body(_encode_body(item))
+
+    assert decoded.dedupe_key == item.dedupe_key
+    assert decoded.asset_name == item.asset_name
+    assert "Codex-authored" in _encode_body(item)
+
+
+def test_duplicate_enqueue_reuses_one_issue():
+    client = FakeGitHubClient()
+    queue = GitHubIssuePublishQueue(client, "splunk-soar-connectors/.github")
+
+    first = queue.enqueue(make_item())
+    second = queue.enqueue(make_item(run_id=456, run_attempt=2))
+
+    assert first.issue_number == second.issue_number
+    assert len(client.issues) == 1
+    assert queue.get_item(first.issue_number).run_id == 456
+
+
+def test_oldest_eligible_skips_future_item():
+    client = FakeGitHubClient()
+    queue = GitHubIssuePublishQueue(client, "splunk-soar-connectors/.github")
+    now = datetime(2026, 7, 29, 12, 0, tzinfo=timezone.utc)
+    queue.enqueue(
+        make_item(
+            repository="splunk-soar-connectors/future",
+            enqueued_at=format_datetime(now - timedelta(hours=2)),
+            not_before=format_datetime(now + timedelta(minutes=1)),
+        )
+    )
+    expected = queue.enqueue(
+        make_item(
+            repository="splunk-soar-connectors/eligible",
+            enqueued_at=format_datetime(now - timedelta(hours=1)),
+        )
+    )
+
+    selected = queue.oldest_eligible("soar-connectors-default", now)
+
+    assert selected.issue_number == expected.issue_number
+
+
+def test_active_item_is_recovered_only_after_its_lease_expires():
+    client = FakeGitHubClient()
+    queue = GitHubIssuePublishQueue(client, "splunk-soar-connectors/.github")
+    now = datetime(2026, 7, 29, 12, 0, tzinfo=timezone.utc)
+    item = queue.enqueue(make_item())
+    queue.activate(item, now + timedelta(minutes=15))
+
+    assert queue.oldest_eligible(item.publisher_alias, now) is None
+    assert (
+        queue.oldest_eligible(
+            item.publisher_alias,
+            now + timedelta(minutes=16),
+        ).issue_number
+        == item.issue_number
+    )
+
+
+def test_rate_ledger_never_reserves_more_than_twelve_in_a_rolling_hour():
+    client = FakeGitHubClient()
+    queue = GitHubIssuePublishQueue(client, "splunk-soar-connectors/.github")
+    item = queue.enqueue(make_item())
+    start = datetime(2026, 7, 29, 12, 0, tzinfo=timezone.utc)
+
+    for index in range(MAX_ATTEMPTS_PER_HOUR):
+        assert (
+            queue.reserve_attempt(
+                item.publisher_alias,
+                item,
+                start + index * MIN_ATTEMPT_INTERVAL,
+            )
+            is None
+        )
+
+    retry_at = queue.reserve_attempt(
+        item.publisher_alias,
+        item,
+        start + timedelta(minutes=59),
+    )
+
+    assert retry_at == start + timedelta(hours=1)
+
+
+def test_state_issue_contains_only_public_operational_metadata():
+    client = FakeGitHubClient()
+    queue = GitHubIssuePublishQueue(client, "splunk-soar-connectors/.github")
+    item = queue.enqueue(make_item())
+    queue.reserve_attempt(
+        item.publisher_alias,
+        item,
+        datetime(2026, 7, 29, 12, 0, tzinfo=timezone.utc),
+    )
+    state_issue = next(issue for issue in client.issues if "queue state" in issue["title"])
+    start = state_issue["body"].index(BODY_START) + len(BODY_START)
+    end = state_issue["body"].index(BODY_END, start)
+    state = json.loads(state_issue["body"][start:end].strip())
+
+    assert set(state) == {"attempts", "publisher_alias"}
+    assert "token" not in state_issue["body"].lower()
+    assert "password" not in state_issue["body"].lower()
+
+
+def test_blocked_issue_does_not_publish_raw_response_text():
+    client = FakeGitHubClient()
+    queue = GitHubIssuePublishQueue(client, "splunk-soar-connectors/.github")
+    item = queue.enqueue(make_item())
+
+    queue.block(
+        item,
+        {
+            "status": "validation_failed",
+            "status_code": 422,
+            "request_id": "request-123",
+            "message": "internal Splunkbase response details",
+        },
+    )
+
+    body = client.issues[0]["body"]
+    assert "validation_failed" in body
+    assert "request-123" in body
+    assert "internal Splunkbase response details" not in body

--- a/.github/utils/test_publish_queue.py
+++ b/.github/utils/test_publish_queue.py
@@ -148,6 +148,36 @@ def test_active_item_is_recovered_only_after_its_lease_expires():
     )
 
 
+def test_verifying_item_is_selected_without_becoming_queued():
+    client = FakeGitHubClient()
+    queue = GitHubIssuePublishQueue(client, "splunk-soar-connectors/.github")
+    now = datetime(2026, 7, 29, 12, 0, tzinfo=timezone.utc)
+    item = queue.enqueue(make_item())
+    queue.verify(
+        item,
+        {
+            "status": "verifying",
+            "package_id": "package-123",
+            "request_id": "request-123",
+        },
+        now,
+        "Waiting for package validation.",
+    )
+
+    selected = queue.oldest_eligible(item.publisher_alias, now)
+
+    assert selected.issue_number == item.issue_number
+    assert selected.verification == {
+        "status": "verifying",
+        "package_id": "package-123",
+        "request_id": "request-123",
+    }
+    assert client.issues[0]["labels"] == [
+        {"name": "splunkbase-publish"},
+        {"name": "splunkbase-verifying"},
+    ]
+
+
 def test_rate_ledger_never_reserves_more_than_twelve_in_a_rolling_hour():
     client = FakeGitHubClient()
     queue = GitHubIssuePublishQueue(client, "splunk-soar-connectors/.github")

--- a/.github/workflows/auto_assign_action.yml
+++ b/.github/workflows/auto_assign_action.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   auto-assign:
+    if: github.repository != 'splunk-soar-connectors/.github'
     runs-on: ubuntu-latest
     steps:
       - name: 'Auto-assign issue'

--- a/.github/workflows/drain-splunkbase-publish-queue.yml
+++ b/.github/workflows/drain-splunkbase-publish-queue.yml
@@ -1,0 +1,115 @@
+name: Drain Splunkbase publish queue
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: splunkbase-publisher-soar-connectors-default
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  select:
+    if: vars.SPLUNKBASE_PUBLISH_QUEUE_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      has_item: ${{ steps.select.outputs.has_item }}
+      issue_number: ${{ steps.select.outputs.issue_number }}
+      repository: ${{ steps.select.outputs.repository }}
+      commit_sha: ${{ steps.select.outputs.commit_sha }}
+      asset_name: ${{ steps.select.outputs.asset_name }}
+    steps:
+      - name: Check out queue implementation
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install queue requirements
+        run: pip install "requests>=2.32.3,<3.0.0" "packaging>=24.2,<26.0"
+
+      - name: Select oldest eligible publication
+        id: select
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          QUEUE_REPOSITORY: ${{ github.repository }}
+        run: python .github/scripts/drain_splunkbase_publish_queue.py select
+
+  publish-one:
+    needs: select
+    if: needs.select.outputs.has_item == 'true'
+    runs-on:
+      - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
+      - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
+    steps:
+      - name: Check out queue implementation
+        uses: actions/checkout@v4
+
+      - name: Install publisher requirements
+        run: pip install -r .github/actions/publish/requirements.txt
+
+      - name: Download immutable connector artifact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          QUEUE_REPOSITORY: ${{ github.repository }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/splunkbase-artifact"
+          python .github/scripts/drain_splunkbase_publish_queue.py download \
+            --issue-number "${{ needs.select.outputs.issue_number }}" \
+            --output "$RUNNER_TEMP/splunkbase-artifact/${{ needs.select.outputs.asset_name }}"
+
+      - name: Check out connector release
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.select.outputs.repository }}
+          ref: ${{ needs.select.outputs.commit_sha }}
+          fetch-depth: 2
+          path: connector
+          persist-credentials: false
+
+      - name: Publish one queued connector
+        id: publish
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          QUEUE_REPOSITORY: ${{ github.repository }}
+          SPLUNKBASE_USER: ${{ secrets.SPLUNKBASE_USER }}
+          SPLUNKBASE_PASSWORD: ${{ secrets.SPLUNKBASE_PASSWORD }}
+        run: |
+          python .github/scripts/drain_splunkbase_publish_queue.py publish \
+            --issue-number "${{ needs.select.outputs.issue_number }}" \
+            --artifact "$RUNNER_TEMP/splunkbase-artifact/${{ needs.select.outputs.asset_name }}" \
+            --connector-workspace "${{ github.workspace }}/connector" \
+            --result-path "$RUNNER_TEMP/splunkbase-publish-result.json" \
+            --publisher-output "$RUNNER_TEMP/splunkbase-publisher-output"
+
+      - name: Send release metrics
+        if: steps.publish.outputs.queue_status == 'published'
+        uses: ./.github/actions/metrics
+        with:
+          publish_return_code: ${{ steps.publish.outputs.publish_return_code }}
+          repo_path: ${{ github.workspace }}/connector
+
+      - name: Notify Slack
+        if: steps.publish.outputs.queue_status == 'published' && vars.SEND_RELEASE_MESSAGE == 'true'
+        uses: ./.github/actions/notify-slack
+        with:
+          app_name: ${{ steps.publish.outputs.app_name }}
+          app_logo: ${{ steps.publish.outputs.app_logo }}
+          repo_name: ${{ steps.publish.outputs.repo_name }}
+          release_version: ${{ steps.publish.outputs.release_version }}
+          release_notes: ${{ steps.publish.outputs.release_notes }}
+          new_app: ${{ steps.publish.outputs.new_app }}
+          support_tag: ${{ steps.publish.outputs.support_tag }}
+          splunk_base_url: ${{ steps.publish.outputs.splunk_base_url }}
+          workspace_path: ${{ github.workspace }}/connector
+          slack_internal_token: ${{ secrets.SLACK_INTERNAL_TOKEN }}
+          slack_community_token: ${{ secrets.SLACK_COMMUNITY_TOKEN }}
+          slack_internal_channel: ${{ vars.SLACK_INTERNAL_CHANNEL_ID }}
+          slack_community_channel: ${{ vars.SLACK_COMMUNITY_CHANNEL_ID }}

--- a/.github/workflows/drain-splunkbase-publish-queue.yml
+++ b/.github/workflows/drain-splunkbase-publish-queue.yml
@@ -23,6 +23,7 @@ jobs:
       repository: ${{ steps.select.outputs.repository }}
       commit_sha: ${{ steps.select.outputs.commit_sha }}
       asset_name: ${{ steps.select.outputs.asset_name }}
+      candidate_version: ${{ steps.select.outputs.candidate_version }}
     steps:
       - name: Check out queue implementation
         uses: actions/checkout@v4
@@ -113,3 +114,16 @@ jobs:
           slack_community_token: ${{ secrets.SLACK_COMMUNITY_TOKEN }}
           slack_internal_channel: ${{ vars.SLACK_INTERNAL_CHANNEL_ID }}
           slack_community_channel: ${{ vars.SLACK_COMMUNITY_CHANNEL_ID }}
+
+      - name: Notify internal Slack of blocked publication
+        if: always() && steps.publish.outputs.queue_status == 'blocked'
+        env:
+          SLACK_INTERNAL_TOKEN: ${{ secrets.SLACK_INTERNAL_TOKEN }}
+          SLACK_INTERNAL_CHANNEL: ${{ vars.SLACK_INTERNAL_CHANNEL_ID }}
+          QUEUE_ISSUE_URL: https://github.com/${{ github.repository }}/issues/${{ needs.select.outputs.issue_number }}
+          CONNECTOR_REPOSITORY: ${{ needs.select.outputs.repository }}
+          CONNECTOR_VERSION: ${{ needs.select.outputs.candidate_version }}
+          SPLUNKBASE_REQUEST_ID: ${{ steps.publish.outputs.request_id }}
+          SPLUNKBASE_PACKAGE_ID: ${{ steps.publish.outputs.package_id }}
+          FAILURE_REASON: ${{ steps.publish.outputs.failure_reason }}
+        run: python .github/scripts/notify_splunkbase_publish_failure.py

--- a/.github/workflows/enqueue-splunkbase-publish.yml
+++ b/.github/workflows/enqueue-splunkbase-publish.yml
@@ -1,0 +1,32 @@
+name: Enqueue Splunkbase publication
+
+on:
+  repository_dispatch:
+    types:
+      - splunkbase-publish-enqueue
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  enqueue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out queue implementation
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install queue requirements
+        run: pip install "requests>=2.32.3,<3.0.0"
+
+      - name: Create or update queue item
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          QUEUE_REPOSITORY: ${{ github.repository }}
+          QUEUE_ITEM_JSON: ${{ toJSON(github.event.client_payload) }}
+        run: python .github/scripts/enqueue_splunkbase_publish.py

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,6 +124,8 @@ jobs:
     if: github.event.repository.name != 'connector-template'
     runs-on: ubuntu-latest
     needs: [semantic-version, detect-app-type]
+    outputs:
+      commit_sha: ${{ steps.source.outputs.commit_sha }}
     env:
       IS_SDKFIED: ${{ needs.detect-app-type.outputs.is_sdkfied }}
       UV_LOCK_DIRECTORY: ${{ needs.detect-app-type.outputs.uv_lock_directory }}
@@ -133,6 +135,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
+
+      - name: Record immutable build source
+        id: source
+        run: echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -237,17 +243,6 @@ jobs:
           repositories: |
             .github
 
-      - name: Check out connector release
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: main
-          persist-credentials: false
-
-      - name: Record immutable release commit
-        id: release
-        run: echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
       - name: Download app tar file for queue storage
         uses: actions/download-artifact@v4
         with:
@@ -258,7 +253,7 @@ jobs:
         uses: splunk-soar-connectors/.github/.github/actions/enqueue-publish@main
         with:
           artifact_path: ${{ github.workspace }}/artifacts/${{ github.event.repository.name }}.tgz
-          commit_sha: ${{ steps.release.outputs.commit_sha }}
+          commit_sha: ${{ needs.build.outputs.commit_sha }}
           github_token: ${{ steps.queue-token.outputs.token }}
 
   metrics:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -172,6 +172,7 @@ jobs:
           path: /tmp/${{ github.event.repository.name }}.tgz
 
   publish:
+    if: vars.SPLUNKBASE_PUBLISH_QUEUE_ENABLED != 'true'
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
       - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
@@ -218,6 +219,47 @@ jobs:
             echo "Publish script failed with return code $return_code, failing the job."
             exit $return_code
           fi
+
+  enqueue-publish:
+    if: vars.SPLUNKBASE_PUBLISH_QUEUE_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+    steps:
+      - name: Create central queue token
+        uses: actions/create-github-app-token@v1
+        id: queue-token
+        with:
+          app-id: ${{ vars.SEMANTIC_RELEASE_APP_ID }}
+          private-key: ${{ secrets.semantic_release_pk }}
+          owner: splunk-soar-connectors
+          repositories: |
+            .github
+
+      - name: Check out connector release
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+          persist-credentials: false
+
+      - name: Record immutable release commit
+        id: release
+        run: echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Download app tar file for queue storage
+        uses: actions/download-artifact@v4
+        with:
+          name: app-tar
+          path: ${{ github.workspace }}/artifacts
+
+      - name: Enqueue serialized Splunkbase publication
+        uses: splunk-soar-connectors/.github/.github/actions/enqueue-publish@main
+        with:
+          artifact_path: ${{ github.workspace }}/artifacts/${{ github.event.repository.name }}.tgz
+          commit_sha: ${{ steps.release.outputs.commit_sha }}
+          github_token: ${{ steps.queue-token.outputs.token }}
 
   metrics:
     runs-on:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   pr-labeling:
     runs-on: ubuntu-latest
-    if: github.event.action == 'opened'
+    if: github.repository != 'splunk-soar-connectors/.github' && github.event.action == 'opened'
     permissions:
       issues: write
       pull-requests: write
@@ -26,6 +26,7 @@ jobs:
 
   detect-app-type:
     runs-on: ubuntu-latest
+    if: github.repository != 'splunk-soar-connectors/.github'
     outputs:
       is_sdkfied: ${{ steps.detect.outputs.is_sdkfied }}
       uv_lock_directory: ${{ steps.detect.outputs.uv_lock_directory }}
@@ -86,6 +87,7 @@ jobs:
 
   pre-commit:
     runs-on: ubuntu-latest
+    if: github.repository != 'splunk-soar-connectors/.github'
     steps:
       - name: Setup Environment
         uses: splunk-soar-connectors/.github/.github/actions/env-setup@main
@@ -95,6 +97,7 @@ jobs:
 
   semantic-release-preview:
     runs-on: ubuntu-latest
+    if: github.repository != 'splunk-soar-connectors/.github'
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Summary

- make every multipart Splunkbase upload a single counted POST while retaining bounded retries for read-only requests
- emit structured rate-limit, permission, ambiguous-transport, and validation outcomes with request IDs and correlation-rich User-Agent fields
- add a durable per-user queue backed by central GitHub issues and prerelease assets
- drain at most one item every five minutes and 12 attempts per rolling hour, with persisted attempt history and stale-worker lease recovery
- move eventual metrics and Slack notifications to the central worker
- keep the queue behind `SPLUNKBASE_PUBLISH_QUEUE_ENABLED`; direct publication remains the fallback until central secrets and a five-connector canary are ready

## Root cause

The shared Splunkbase user is limited to 20 upload attempts per hour, every attempt counts, and the prior HTTP adapter could turn one connector job into 11 multipart POSTs. Repository-local workflow concurrency cannot coordinate that per-user quota across the connector organization.

## Rollout

Merging immediately removes automatic upload POST retries. The central queue remains disabled until `SPLUNKBASE_USER`, `SPLUNKBASE_PASSWORD`, and Slack secrets are configured on this repository. Enable `SPLUNKBASE_PUBLISH_QUEUE_ENABLED` for five approved canary repositories first, then expose it organization-wide after verifying five-minute spacing and successful notifications. The runbook is `.github/SPLUNKBASE_PUBLISH_QUEUE.md`.

Do not use CrowdSec or Microsoft OneDrive v2 for the canary.

## Validation

- full repository suite: 73 passed, 3 subtests passed
- `pre-commit run --all-files --show-diff-on-failure`
- `actionlint` on all changed workflows
- `git diff --check`
- deterministic simulation: 12:00, 12:05, and 12:10 upload slots
- both commits are GPG-signed

Epic: ESPM-5228

Written by Codex.