### PR TITLE
fix: recover Splunkbase publish queue pilot

### DIFF
--- a/.github/actions/enqueue-publish/action.yml
+++ b/.github/actions/enqueue-publish/action.yml
@@ -54,12 +54,28 @@ runs:
         RELEASE_TAG: ${{ inputs.release_tag }}
       run: |
         if ! gh release view "$RELEASE_TAG" --repo "$QUEUE_REPOSITORY" >/dev/null 2>&1; then
+          create_log="${RUNNER_TEMP}/splunkbase-release-create.log"
           if ! gh release create "$RELEASE_TAG" \
               --repo "$QUEUE_REPOSITORY" \
+              --target main \
               --prerelease \
               --title "Splunkbase publish queue" \
-              --notes "Operational artifact storage managed by Codex-authored automation."; then
-            gh release view "$RELEASE_TAG" --repo "$QUEUE_REPOSITORY" >/dev/null
+              --notes "Operational artifact storage managed by Codex-authored automation." \
+              2>"$create_log"; then
+            release_visible=false
+            for delay in 1 2 3 4 5; do
+              if gh release view "$RELEASE_TAG" \
+                  --repo "$QUEUE_REPOSITORY" >/dev/null 2>&1; then
+                release_visible=true
+                break
+              fi
+              sleep "$delay"
+            done
+            if [ "$release_visible" != "true" ]; then
+              cat "$create_log" >&2
+              exit 1
+            fi
+            echo "Another publisher created the queue release."
           fi
         fi
         gh release view "$RELEASE_TAG" --repo "$QUEUE_REPOSITORY" >/dev/null

--- a/.github/actions/enqueue-publish/action.yml
+++ b/.github/actions/enqueue-publish/action.yml
@@ -32,11 +32,16 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v9
+      with:
+        enable-cache: true
+
     - name: Prepare queue metadata
       id: prepare
       shell: bash
       run: |
-        python "${{ github.action_path }}/prepare_enqueue.py" \
+        uv run "${{ github.action_path }}/prepare_enqueue.py" \
           --artifact "${{ inputs.artifact_path }}" \
           --repository "${{ github.repository }}" \
           --commit-sha "${{ inputs.commit_sha }}" \

--- a/.github/actions/enqueue-publish/prepare_enqueue.py
+++ b/.github/actions/enqueue-publish/prepare_enqueue.py
@@ -37,6 +37,15 @@ def write_output(name: str, value: str) -> None:
             output.write(f"{name}={value}\n")
 
 
+def build_dispatch_payload(queue_item: dict) -> dict:
+    """Nest queue metadata under one repository-dispatch payload property."""
+
+    return {
+        "event_type": "splunkbase-publish-enqueue",
+        "client_payload": {"queue_item": queue_item},
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--artifact", type=Path, required=True)
@@ -58,25 +67,23 @@ def main() -> int:
         f"{safe_asset_part(args.commit_sha[:12])}.tgz"
     )
     now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    payload = {
-        "event_type": "splunkbase-publish-enqueue",
-        "client_payload": {
-            "schema_version": 1,
-            "publisher_alias": args.publisher_alias,
-            "repository": args.repository,
-            "run_id": args.run_id,
-            "run_attempt": args.run_attempt,
-            "commit_sha": args.commit_sha,
-            "artifact_name": "app-tar",
-            "asset_name": asset_name,
-            "release_tag": args.release_tag,
-            "candidate_version": version,
-            "appid": str(app_json["appid"]),
-            "app_name": str(app_json["name"]),
-            "enqueued_at": now,
-            "not_before": now,
-        },
+    queue_item = {
+        "schema_version": 1,
+        "publisher_alias": args.publisher_alias,
+        "repository": args.repository,
+        "run_id": args.run_id,
+        "run_attempt": args.run_attempt,
+        "commit_sha": args.commit_sha,
+        "artifact_name": "app-tar",
+        "asset_name": asset_name,
+        "release_tag": args.release_tag,
+        "candidate_version": version,
+        "appid": str(app_json["appid"]),
+        "app_name": str(app_json["name"]),
+        "enqueued_at": now,
+        "not_before": now,
     }
+    payload = build_dispatch_payload(queue_item)
     args.payload_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
     write_output("asset_name", asset_name)

--- a/.github/actions/enqueue-publish/prepare_enqueue.py
+++ b/.github/actions/enqueue-publish/prepare_enqueue.py
@@ -1,3 +1,7 @@
+# /// script
+# requires-python = ">=3.13,<3.14"
+# dependencies = []
+# ///
 """Prepare immutable Splunkbase queue metadata from a connector package."""
 
 import argparse

--- a/.github/actions/enqueue-publish/test_prepare_enqueue.py
+++ b/.github/actions/enqueue-publish/test_prepare_enqueue.py
@@ -29,3 +29,17 @@ def test_app_metadata_and_asset_name_are_stable(tmp_path):
     assert (
         MODULE.safe_asset_part("splunk-soar-connectors/example") == "splunk-soar-connectors-example"
     )
+
+
+def test_dispatch_payload_nests_queue_metadata_under_one_property():
+    queue_item = {
+        "repository": "splunk-soar-connectors/example",
+        "candidate_version": "2.3.4",
+        "appid": "example-guid",
+    }
+
+    payload = MODULE.build_dispatch_payload(queue_item)
+
+    assert payload["event_type"] == "splunkbase-publish-enqueue"
+    assert payload["client_payload"] == {"queue_item": queue_item}
+    assert len(payload["client_payload"]) == 1

--- a/.github/scripts/drain_splunkbase_publish_queue.py
+++ b/.github/scripts/drain_splunkbase_publish_queue.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.13,<3.14"
+# dependencies = [
+#   "backoff>=2.2.1,<3.0.0",
+#   "packaging>=24.2,<26.0",
+#   "requests>=2.32.3,<3.0.0",
+# ]
+# ///
 """Select and publish one item from the shared-user Splunkbase queue."""
 
 from __future__ import annotations

--- a/.github/scripts/enqueue_splunkbase_publish.py
+++ b/.github/scripts/enqueue_splunkbase_publish.py
@@ -12,10 +12,19 @@ sys.path.insert(0, str(REPO_ROOT))
 from utils.publish_queue import GitHubClient, GitHubIssuePublishQueue, PublishQueueItem
 
 
+def unwrap_queue_item(payload: dict) -> dict:
+    """Accept the bounded nested payload and legacy flat payloads."""
+
+    queue_item = payload.get("queue_item", payload)
+    if not isinstance(queue_item, dict):
+        raise ValueError("Repository dispatch queue_item must be an object")
+    return queue_item
+
+
 def main() -> int:
     token = os.environ["GITHUB_TOKEN"]
     repository = os.environ["QUEUE_REPOSITORY"]
-    payload = json.loads(os.environ["QUEUE_ITEM_JSON"])
+    payload = unwrap_queue_item(json.loads(os.environ["QUEUE_ITEM_JSON"]))
     queue = GitHubIssuePublishQueue(GitHubClient(token), repository)
     item = queue.enqueue(PublishQueueItem.from_dict(payload))
     print(f"Queued {item.repository} v{item.candidate_version} as issue #{item.issue_number}")

--- a/.github/scripts/enqueue_splunkbase_publish.py
+++ b/.github/scripts/enqueue_splunkbase_publish.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.13,<3.14"
+# dependencies = [
+#   "requests>=2.32.3,<3.0.0",
+# ]
+# ///
 """Create or update one durable Splunkbase queue item."""
 
 import json

--- a/.github/scripts/notify_splunkbase_publish_failure.py
+++ b/.github/scripts/notify_splunkbase_publish_failure.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.13,<3.14"
+# dependencies = [
+#   "requests>=2.32.3,<3.0.0",
+# ]
+# ///
 """Notify the internal connector channel about a terminal queue failure."""
 
 from __future__ import annotations

--- a/.github/scripts/test_enqueue_splunkbase_publish.py
+++ b/.github/scripts/test_enqueue_splunkbase_publish.py
@@ -1,0 +1,27 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).with_name("enqueue_splunkbase_publish.py")
+SPEC = importlib.util.spec_from_file_location("enqueue_splunkbase_publish", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_nested_repository_dispatch_payload_is_unwrapped():
+    queue_item = {"repository": "splunk-soar-connectors/example"}
+
+    assert MODULE.unwrap_queue_item({"queue_item": queue_item}) == queue_item
+
+
+def test_legacy_flat_repository_dispatch_payload_remains_accepted():
+    queue_item = {"repository": "splunk-soar-connectors/example"}
+
+    assert MODULE.unwrap_queue_item(queue_item) == queue_item
+
+
+def test_non_object_queue_item_is_rejected():
+    with pytest.raises(ValueError, match="must be an object"):
+        MODULE.unwrap_queue_item({"queue_item": "invalid"})

--- a/.github/test_publish_workflow.py
+++ b/.github/test_publish_workflow.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 WORKFLOW = Path(__file__).parent / "workflows" / "publish.yml"
 DRAIN_WORKFLOW = Path(__file__).parent / "workflows" / "drain-splunkbase-publish-queue.yml"
+ENQUEUE_ACTION = Path(__file__).parent / "actions" / "enqueue-publish" / "action.yml"
 
 
 def test_enqueue_uses_the_commit_that_created_the_artifact():
@@ -32,3 +33,32 @@ def test_drain_notifies_internal_slack_only_for_terminal_blocked_items():
     assert "queue_status == 'verifying'" not in notification
     assert "queue_status == 'deferred'" not in notification
     assert "queue_status == 'rate_limited'" not in notification
+
+
+def test_skipped_direct_publish_cannot_trigger_release_slack():
+    workflow = WORKFLOW.read_text()
+    notify = workflow.split("\n  notify-slack:\n", 1)[1]
+
+    assert "needs.publish.result != 'skipped'" in notify
+    assert "needs.publish.outputs.return_code != ''" in notify
+
+
+def test_drain_selector_installs_every_imported_runtime_dependency():
+    workflow = DRAIN_WORKFLOW.read_text()
+    select = workflow.split("\n  select:\n", 1)[1].split("\n  publish-one:\n", 1)[0]
+
+    assert '"backoff>=2.2.1,<3.0.0"' in select
+    assert '"requests>=2.32.3,<3.0.0"' in select
+    assert '"packaging>=24.2,<26.0"' in select
+
+
+def test_concurrent_queue_release_creation_waits_for_the_winner():
+    action = ENQUEUE_ACTION.read_text()
+    release_step = action.split(
+        "\n    - name: Ensure durable queue release exists\n",
+        1,
+    )[1].split("\n    - name: Store immutable connector artifact\n", 1)[0]
+
+    assert "--target main" in release_step
+    assert "for delay in 1 2 3 4 5" in release_step
+    assert 'if [ "$release_visible" != "true" ]' in release_step

--- a/.github/test_publish_workflow.py
+++ b/.github/test_publish_workflow.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 WORKFLOW = Path(__file__).parent / "workflows" / "publish.yml"
 DRAIN_WORKFLOW = Path(__file__).parent / "workflows" / "drain-splunkbase-publish-queue.yml"
+ENQUEUE_WORKFLOW = Path(__file__).parent / "workflows" / "enqueue-splunkbase-publish.yml"
 ENQUEUE_ACTION = Path(__file__).parent / "actions" / "enqueue-publish" / "action.yml"
 
 
@@ -43,13 +44,41 @@ def test_skipped_direct_publish_cannot_trigger_release_slack():
     assert "needs.publish.outputs.return_code != ''" in notify
 
 
-def test_drain_selector_installs_every_imported_runtime_dependency():
+def test_queue_workflows_execute_self_contained_uv_scripts():
     workflow = DRAIN_WORKFLOW.read_text()
+    enqueue_workflow = ENQUEUE_WORKFLOW.read_text()
+    enqueue_action = ENQUEUE_ACTION.read_text()
     select = workflow.split("\n  select:\n", 1)[1].split("\n  publish-one:\n", 1)[0]
+    publish = workflow.split("\n  publish-one:\n", 1)[1]
+    drain_script = (
+        Path(__file__).parent / "scripts" / "drain_splunkbase_publish_queue.py"
+    ).read_text()
+    enqueue_script = (
+        Path(__file__).parent / "scripts" / "enqueue_splunkbase_publish.py"
+    ).read_text()
+    prepare_script = (
+        Path(__file__).parent / "actions" / "enqueue-publish" / "prepare_enqueue.py"
+    ).read_text()
+    notify_script = (
+        Path(__file__).parent / "scripts" / "notify_splunkbase_publish_failure.py"
+    ).read_text()
 
-    assert '"backoff>=2.2.1,<3.0.0"' in select
-    assert '"requests>=2.32.3,<3.0.0"' in select
-    assert '"packaging>=24.2,<26.0"' in select
+    assert "uses: astral-sh/setup-uv@v9" in select
+    assert "uv run .github/scripts/drain_splunkbase_publish_queue.py select" in select
+    assert "uv run .github/scripts/drain_splunkbase_publish_queue.py download" in publish
+    assert "uv run .github/scripts/drain_splunkbase_publish_queue.py publish" in publish
+    assert "uv run .github/scripts/notify_splunkbase_publish_failure.py" in publish
+    assert "uses: astral-sh/setup-uv@v9" in enqueue_workflow
+    assert "uv run .github/scripts/enqueue_splunkbase_publish.py" in enqueue_workflow
+    assert "uses: astral-sh/setup-uv@v9" in enqueue_action
+    assert 'uv run "${{ github.action_path }}/prepare_enqueue.py"' in enqueue_action
+    assert "pip install" not in select
+    assert '"backoff>=2.2.1,<3.0.0"' in drain_script
+    assert '"requests>=2.32.3,<3.0.0"' in drain_script
+    assert '"packaging>=24.2,<26.0"' in drain_script
+    assert '"requests>=2.32.3,<3.0.0"' in enqueue_script
+    assert "dependencies = []" in prepare_script
+    assert '"requests>=2.32.3,<3.0.0"' in notify_script
 
 
 def test_concurrent_queue_release_creation_waits_for_the_winner():

--- a/.github/workflows/drain-splunkbase-publish-queue.yml
+++ b/.github/workflows/drain-splunkbase-publish-queue.yml
@@ -34,7 +34,11 @@ jobs:
           python-version: "3.13"
 
       - name: Install queue requirements
-        run: pip install "requests>=2.32.3,<3.0.0" "packaging>=24.2,<26.0"
+        run: >-
+          pip install
+          "backoff>=2.2.1,<3.0.0"
+          "requests>=2.32.3,<3.0.0"
+          "packaging>=24.2,<26.0"
 
       - name: Select oldest eligible publication
         id: select

--- a/.github/workflows/drain-splunkbase-publish-queue.yml
+++ b/.github/workflows/drain-splunkbase-publish-queue.yml
@@ -28,24 +28,17 @@ jobs:
       - name: Check out queue implementation
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v9
         with:
-          python-version: "3.13"
-
-      - name: Install queue requirements
-        run: >-
-          pip install
-          "backoff>=2.2.1,<3.0.0"
-          "requests>=2.32.3,<3.0.0"
-          "packaging>=24.2,<26.0"
+          enable-cache: true
 
       - name: Select oldest eligible publication
         id: select
         env:
           GITHUB_TOKEN: ${{ github.token }}
           QUEUE_REPOSITORY: ${{ github.repository }}
-        run: python .github/scripts/drain_splunkbase_publish_queue.py select
+        run: uv run .github/scripts/drain_splunkbase_publish_queue.py select
 
   publish-one:
     needs: select
@@ -57,8 +50,10 @@ jobs:
       - name: Check out queue implementation
         uses: actions/checkout@v4
 
-      - name: Install publisher requirements
-        run: pip install -r .github/actions/publish/requirements.txt
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v9
+        with:
+          enable-cache: true
 
       - name: Download immutable connector artifact
         env:
@@ -66,7 +61,7 @@ jobs:
           QUEUE_REPOSITORY: ${{ github.repository }}
         run: |
           mkdir -p "$RUNNER_TEMP/splunkbase-artifact"
-          python .github/scripts/drain_splunkbase_publish_queue.py download \
+          uv run .github/scripts/drain_splunkbase_publish_queue.py download \
             --issue-number "${{ needs.select.outputs.issue_number }}" \
             --output "$RUNNER_TEMP/splunkbase-artifact/${{ needs.select.outputs.asset_name }}"
 
@@ -87,7 +82,7 @@ jobs:
           SPLUNKBASE_USER: ${{ secrets.SPLUNKBASE_USER }}
           SPLUNKBASE_PASSWORD: ${{ secrets.SPLUNKBASE_PASSWORD }}
         run: |
-          python .github/scripts/drain_splunkbase_publish_queue.py publish \
+          uv run .github/scripts/drain_splunkbase_publish_queue.py publish \
             --issue-number "${{ needs.select.outputs.issue_number }}" \
             --artifact "$RUNNER_TEMP/splunkbase-artifact/${{ needs.select.outputs.asset_name }}" \
             --connector-workspace "${{ github.workspace }}/connector" \
@@ -130,4 +125,4 @@ jobs:
           SPLUNKBASE_REQUEST_ID: ${{ steps.publish.outputs.request_id }}
           SPLUNKBASE_PACKAGE_ID: ${{ steps.publish.outputs.package_id }}
           FAILURE_REASON: ${{ steps.publish.outputs.failure_reason }}
-        run: python .github/scripts/notify_splunkbase_publish_failure.py
+        run: uv run .github/scripts/notify_splunkbase_publish_failure.py

--- a/.github/workflows/enqueue-splunkbase-publish.yml
+++ b/.github/workflows/enqueue-splunkbase-publish.yml
@@ -16,17 +16,14 @@ jobs:
       - name: Check out queue implementation
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v9
         with:
-          python-version: "3.13"
-
-      - name: Install queue requirements
-        run: pip install "requests>=2.32.3,<3.0.0"
+          enable-cache: true
 
       - name: Create or update queue item
         env:
           GITHUB_TOKEN: ${{ github.token }}
           QUEUE_REPOSITORY: ${{ github.repository }}
           QUEUE_ITEM_JSON: ${{ toJSON(github.event.client_payload) }}
-        run: python .github/scripts/enqueue_splunkbase_publish.py
+        run: uv run .github/scripts/enqueue_splunkbase_publish.py

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -284,7 +284,13 @@ jobs:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
       - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
     needs: publish
-    if: always() && vars.SEND_RELEASE_MESSAGE == 'true' && (needs.publish.outputs.return_code == '0' || needs.publish.outputs.return_code == '2')
+    if: >-
+      always() &&
+      vars.SEND_RELEASE_MESSAGE == 'true' &&
+      needs.publish.result != 'skipped' &&
+      needs.publish.outputs.return_code != '' &&
+      (needs.publish.outputs.return_code == '0' ||
+      needs.publish.outputs.return_code == '2')
     steps:
       - name: Check out app repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- nest queue metadata under one repository-dispatch property so the payload stays within GitHub limits
- suppress the legacy release notification when direct publishing is skipped
- install the selector runtime dependencies before the central drain imports the publisher client
- tolerate concurrent first-run queue release creation without surfacing a losing race as a failure
- retain compatibility with legacy flat dispatch payloads

## Root cause

The five canary runs stored their immutable artifacts successfully, then repository dispatch rejected fourteen top-level client payload properties. GitHub expression coercion also treated the skipped direct publish output as zero and started the legacy Slack job with empty release data. Separately, the first scheduled drain failed while importing backoff because the selector installed only requests and packaging.

No Splunkbase multipart upload was attempted, and no shared-user quota was consumed.

## Recovery

After this change merges, the five already-stored canary artifacts can be dispatched directly into the central queue without rerunning semantic-release or rebuilding connector packages.

Campaign: ESPM-5228

## Validation

- 43 focused queue, dispatch, workflow, and recovery tests pass
- pre-commit passes, including YAML validation, Ruff, formatting, and ShellCheck

Written by Codex.