### PR TITLE
fix: bootstrap uv with allowed actions

### DIFF
--- a/.github/actions/enqueue-publish/action.yml
+++ b/.github/actions/enqueue-publish/action.yml
@@ -32,10 +32,14 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up uv
-      uses: astral-sh/setup-uv@v9
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
-        enable-cache: true
+        python-version: "3.13"
+
+    - name: Install uv
+      shell: bash
+      run: python -m pip install "uv==0.12.0"
 
     - name: Prepare queue metadata
       id: prepare

--- a/.github/test_publish_workflow.py
+++ b/.github/test_publish_workflow.py
@@ -63,16 +63,25 @@ def test_queue_workflows_execute_self_contained_uv_scripts():
         Path(__file__).parent / "scripts" / "notify_splunkbase_publish_failure.py"
     ).read_text()
 
-    assert "uses: astral-sh/setup-uv@v9" in select
+    assert "uses: astral-sh/setup-uv" not in workflow
+    assert "uses: actions/setup-python@v5" in select
+    assert 'python -m pip install "uv==0.12.0"' in select
     assert "uv run .github/scripts/drain_splunkbase_publish_queue.py select" in select
     assert "uv run .github/scripts/drain_splunkbase_publish_queue.py download" in publish
     assert "uv run .github/scripts/drain_splunkbase_publish_queue.py publish" in publish
     assert "uv run .github/scripts/notify_splunkbase_publish_failure.py" in publish
-    assert "uses: astral-sh/setup-uv@v9" in enqueue_workflow
+    assert "uses: astral-sh/setup-uv" not in enqueue_workflow
+    assert "uses: actions/setup-python@v5" in enqueue_workflow
+    assert 'python -m pip install "uv==0.12.0"' in enqueue_workflow
     assert "uv run .github/scripts/enqueue_splunkbase_publish.py" in enqueue_workflow
-    assert "uses: astral-sh/setup-uv@v9" in enqueue_action
+    assert "uses: astral-sh/setup-uv" not in enqueue_action
+    assert "uses: actions/setup-python@v5" in enqueue_action
+    assert 'python -m pip install "uv==0.12.0"' in enqueue_action
     assert 'uv run "${{ github.action_path }}/prepare_enqueue.py"' in enqueue_action
-    assert "pip install" not in select
+    assert "pip install -r" not in select
+    assert "backoff" not in select
+    assert "packaging" not in select
+    assert "requests" not in select
     assert '"backoff>=2.2.1,<3.0.0"' in drain_script
     assert '"requests>=2.32.3,<3.0.0"' in drain_script
     assert '"packaging>=24.2,<26.0"' in drain_script

--- a/.github/workflows/drain-splunkbase-publish-queue.yml
+++ b/.github/workflows/drain-splunkbase-publish-queue.yml
@@ -28,10 +28,13 @@ jobs:
       - name: Check out queue implementation
         uses: actions/checkout@v4
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v9
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          enable-cache: true
+          python-version: "3.13"
+
+      - name: Install uv
+        run: python -m pip install "uv==0.12.0"
 
       - name: Select oldest eligible publication
         id: select
@@ -50,10 +53,13 @@ jobs:
       - name: Check out queue implementation
         uses: actions/checkout@v4
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v9
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          enable-cache: true
+          python-version: "3.13"
+
+      - name: Install uv
+        run: python -m pip install "uv==0.12.0"
 
       - name: Download immutable connector artifact
         env:

--- a/.github/workflows/enqueue-splunkbase-publish.yml
+++ b/.github/workflows/enqueue-splunkbase-publish.yml
@@ -16,10 +16,13 @@ jobs:
       - name: Check out queue implementation
         uses: actions/checkout@v4
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v9
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          enable-cache: true
+          python-version: "3.13"
+
+      - name: Install uv
+        run: python -m pip install "uv==0.12.0"
 
       - name: Create or update queue item
         env:


### PR DESCRIPTION
## Summary

- Replaces the enterprise-blocked setup-uv action with the allowed setup-python action.
- Installs uv 0.12.0 as the workflow bootstrap while retaining PEP 723 dependency metadata in each queue script.
- Covers the composite enqueue action and both central queue workflows.

## Root cause

The connector organization action policy does not allow astral-sh/setup-uv, so GitHub rejected canary enqueue jobs before any script executed. No Splunkbase upload attempts were made.

## Validation

- 43 focused queue and workflow tests passed.
- Full pre-commit suite passed, including YAML validation, Ruff, and ShellCheck.

Written by Codex.