### PR TITLE
fix: harden queued publication lifecycle

### DIFF
--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -62,7 +62,7 @@ runs:
         NEW_APP: ${{ inputs.new_app }}
         SUPPORT_TAG: ${{ inputs.support_tag }}
         SPLUNK_BASE_URL: ${{ inputs.splunk_base_url }}
-        GITHUB_WORKSPACE: ${{ inputs.workspace_path }}
+        CONNECTOR_WORKSPACE: ${{ inputs.workspace_path }}
         SLACK_INTERNAL_TOKEN: ${{ inputs.slack_internal_token }}
         SLACK_COMMUNITY_TOKEN: ${{ inputs.slack_community_token }}
         SLACK_INTERNAL_CHANNEL: ${{ inputs.slack_internal_channel }}

--- a/.github/actions/notify-slack/notify_slack.py
+++ b/.github/actions/notify-slack/notify_slack.py
@@ -115,14 +115,14 @@ def _build_message(
 
 def _convert_svg_logo_to_png(repo_name, repo_svg_logo_path):
     """
-    Reads the SVG logo from the local checkout (GITHUB_WORKSPACE) and returns PNG bytes.
+    Reads the SVG logo from the connector checkout and returns PNG bytes.
     If the SVG embeds a raster image (data:image/png;base64,...), extract it directly
     rather than using cairosvg, which doesn't handle embedded bitmaps.
     """
     import base64
     import re as _re
 
-    workspace = os.getenv("GITHUB_WORKSPACE", ".")
+    workspace = os.getenv("CONNECTOR_WORKSPACE", os.getenv("GITHUB_WORKSPACE", "."))
     svg_path = Path(workspace) / repo_svg_logo_path
     logging.info("Reading SVG logo from %s (repo: %s)", svg_path, repo_name)
     svg_bytes = svg_path.read_bytes()

--- a/.github/scripts/drain_splunkbase_publish_queue.py
+++ b/.github/scripts/drain_splunkbase_publish_queue.py
@@ -19,6 +19,7 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+import time
 
 from packaging.version import parse
 
@@ -37,6 +38,9 @@ from utils.publish_queue import (
     parse_datetime,
     utc_now,
 )
+
+VERIFICATION_POLL_INTERVAL_SECONDS = 10
+VERIFICATION_POLL_TIMEOUT_SECONDS = 5 * 60
 
 
 def write_output(name: str, value: str | int | bool) -> None:
@@ -203,7 +207,7 @@ def defer_verification(queue, item, result, now, reason) -> int:
     queue.verify(
         item,
         result,
-        now + MIN_ATTEMPT_INTERVAL,
+        now + timedelta(seconds=VERIFICATION_POLL_INTERVAL_SECONDS),
         reason,
     )
     write_output("queue_status", "verifying")
@@ -235,10 +239,9 @@ def interrupted_attempt(item) -> dict | None:
     return result
 
 
-def reconcile_verification(queue, client, item, args, now) -> int:
-    """Reconcile an accepted package using GETs only."""
+def check_verification(queue, client, item, args, result, now) -> int | None:
+    """Perform one GET-only publication check."""
 
-    result = dict(item.verification or {})
     package_id = result.get("package_id")
 
     try:
@@ -248,33 +251,15 @@ def reconcile_verification(queue, client, item, args, now) -> int:
         print("The release listing could not be read; checking the accepted package directly.")
 
     if not package_id:
-        return defer_verification(
-            queue,
-            item,
-            result,
-            now,
-            "An accepted upload has no package ID; waiting for version-only reconciliation.",
-        )
+        return None
 
     try:
-        response = client.check_upload_status(package_id)
+        response = client.get_upload_status(package_id)
     except Exception:
-        return defer_verification(
-            queue,
-            item,
-            result,
-            now,
-            "The accepted package could not be read; GET-only verification will retry.",
-        )
+        return None
 
     if not isinstance(response, dict):
-        return defer_verification(
-            queue,
-            item,
-            result,
-            now,
-            "Splunkbase returned a malformed package status; GET-only verification will retry.",
-        )
+        return None
 
     splunkbase_app_id = response.get("details", {}).get("id")
     if splunkbase_app_id:
@@ -289,13 +274,7 @@ def reconcile_verification(queue, client, item, args, now) -> int:
     if client._is_retryable_response(response) or not Splunkbase.is_definitive_validation_failure(
         response
     ):
-        return defer_verification(
-            queue,
-            item,
-            result,
-            now,
-            "Splunkbase validation is still pending; GET-only verification will retry.",
-        )
+        return None
 
     result["status"] = "validation_failed"
     return block_publication(
@@ -305,6 +284,30 @@ def reconcile_verification(queue, client, item, args, now) -> int:
         f"Splunkbase definitively rejected accepted package {package_id}.",
         return_code=13,
     )
+
+
+def reconcile_verification(queue, client, item, args, _now) -> int:
+    """Poll an accepted package every ten seconds using GETs only."""
+
+    result = dict(item.verification or {})
+    deadline = time.monotonic() + VERIFICATION_POLL_TIMEOUT_SECONDS
+
+    while True:
+        outcome = check_verification(queue, client, item, args, result, utc_now())
+        if outcome is not None:
+            return outcome
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return defer_verification(
+                queue,
+                item,
+                result,
+                utc_now(),
+                "Splunkbase publication was not confirmed within five minutes; "
+                "GET-only verification will retry.",
+            )
+        time.sleep(min(VERIFICATION_POLL_INTERVAL_SECONDS, remaining))
 
 
 def publish_item(args) -> int:
@@ -327,19 +330,15 @@ def publish_item(args) -> int:
 
     interrupted = interrupted_attempt(item)
     if interrupted:
-        try:
-            if version_exists(splunkbase, item.appid, item.candidate_version):
-                return finalize_publication(queue, splunkbase, item, args, interrupted, now)
-        except Exception:
-            pass
-        return defer_verification(
-            queue,
+        item.verification = interrupted
+        queue.verify(
             item,
             interrupted,
             now,
             "A counted upload attempt ended without a durable result; "
-            "GET-only reconciliation will continue until a human authorizes another POST.",
+            "immediate GET-only reconciliation started.",
         )
+        return reconcile_verification(queue, splunkbase, item, args, now)
 
     if version_exists(splunkbase, item.appid, item.candidate_version):
         return finalize_publication(
@@ -394,13 +393,14 @@ def publish_item(args) -> int:
         return finalize_publication(queue, splunkbase, item, args, result, now)
 
     if status == "verifying":
-        return defer_verification(
-            queue,
+        item.verification = result
+        queue.verify(
             item,
             result,
             now,
-            "Splunkbase accepted the upload; GET-only verification will retry.",
+            "Splunkbase accepted the upload; immediate GET-only verification started.",
         )
+        return reconcile_verification(queue, splunkbase, item, args, now)
 
     if status == "rate_limited":
         item.attempts[-1]["outcome"] = "rate_limited"
@@ -421,13 +421,14 @@ def publish_item(args) -> int:
         if version_exists(splunkbase, item.appid, item.candidate_version):
             result["status"] = "reconciled_published"
             return finalize_publication(queue, splunkbase, item, args, result, now)
-        return defer_verification(
-            queue,
+        item.verification = result
+        queue.verify(
             item,
             result,
             now,
-            "The upload result is ambiguous; GET-only reconciliation will retry.",
+            "The upload result is ambiguous; immediate GET-only reconciliation started.",
         )
+        return reconcile_verification(queue, splunkbase, item, args, now)
 
     return block_publication(
         queue,

--- a/.github/scripts/test_drain_splunkbase_publish_queue.py
+++ b/.github/scripts/test_drain_splunkbase_publish_queue.py
@@ -12,6 +12,11 @@ MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 
 
+@pytest.fixture(autouse=True)
+def disable_verification_wait(monkeypatch):
+    monkeypatch.setattr(MODULE, "VERIFICATION_POLL_TIMEOUT_SECONDS", 0)
+
+
 def test_retry_after_supports_seconds_and_http_dates():
     now = MODULE.parse_datetime("2026-07-29T12:00:00Z")
 
@@ -102,7 +107,7 @@ def test_verification_get_failures_do_not_post_or_reserve(monkeypatch, validatio
     queue = Mock()
     client = Mock()
     client.get_existing_releases.return_value = []
-    client.check_upload_status.side_effect = validation_error
+    client.get_upload_status.side_effect = validation_error
     run_publisher = Mock()
     monkeypatch.setattr(MODULE, "run_publisher", run_publisher)
 
@@ -118,6 +123,44 @@ def test_verification_get_failures_do_not_post_or_reserve(monkeypatch, validatio
     queue.verify.assert_called_once()
     queue.reserve_attempt.assert_not_called()
     run_publisher.assert_not_called()
+
+
+def test_verification_polls_every_ten_seconds_until_release_appears(monkeypatch):
+    queue = Mock()
+    client = Mock()
+    client.get_existing_releases.side_effect = [
+        [],
+        [],
+        [{"release_name": "1.2.3"}],
+    ]
+    client.get_upload_status.return_value = {"message": "Package validation still in progress."}
+    client._is_retryable_response.return_value = True
+    client.get_apps.return_value = [{"id": "app-123", "support": "splunk"}]
+    clock = [0]
+
+    def advance_clock(seconds):
+        assert seconds == 10
+        clock[0] += seconds
+
+    monkeypatch.setattr(MODULE, "VERIFICATION_POLL_TIMEOUT_SECONDS", 300)
+    monkeypatch.setattr(MODULE.time, "monotonic", lambda: clock[0])
+    sleep = Mock(side_effect=advance_clock)
+    monkeypatch.setattr(MODULE.time, "sleep", sleep)
+    monkeypatch.setattr(MODULE, "load_publisher_module", publisher_metadata)
+
+    result = MODULE.reconcile_verification(
+        queue,
+        client,
+        verifying_item(),
+        finalization_args(),
+        MODULE.parse_datetime("2026-07-29T12:00:00Z"),
+    )
+
+    assert result == 0
+    assert sleep.call_args_list == [((10,),), ((10,),)]
+    assert client.get_upload_status.call_count == 2
+    queue.complete.assert_called_once()
+    queue.reserve_attempt.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -164,7 +207,7 @@ def test_recovery_paths_share_finalization_without_post_or_reserve(
         result = MODULE.publish_item(finalization_args())
 
     assert result == 0
-    client.check_upload_status.assert_not_called()
+    client.get_upload_status.assert_not_called()
     if expected_new_app:
         client.ensure_app_editors.assert_called_once_with("app-123")
     else:
@@ -214,10 +257,6 @@ def test_ambiguous_upload_is_finalized_when_version_appears_without_second_post(
     monkeypatch.setattr(MODULE, "write_output", outputs.__setitem__)
     monkeypatch.setenv("SPLUNKBASE_USER", "publisher")
     monkeypatch.setenv("SPLUNKBASE_PASSWORD", "password")
-
-    assert MODULE.publish_item(finalization_args()) == 0
-    verification_result = queue.verify.call_args.args[1]
-    item.verification = verification_result
 
     assert MODULE.publish_item(finalization_args()) == 0
 
@@ -305,7 +344,7 @@ def test_app_existence_snapshot_is_persisted_before_publisher_runs(monkeypatch):
 
     assert events == ["recorded", "publisher"]
     assert item.attempts[-1]["app_existed_before_upload"] is False
-    queue.verify.assert_called_once()
+    assert queue.verify.call_count == 2
     assert outputs["queue_status"] == "verifying"
 
 
@@ -339,7 +378,7 @@ def test_continued_pending_validation_does_not_post_or_reserve(monkeypatch):
     queue = Mock()
     client = Mock()
     client.get_existing_releases.return_value = []
-    client.check_upload_status.return_value = {"message": "Package validation still in progress."}
+    client.get_upload_status.return_value = {"message": "Package validation still in progress."}
     client._is_retryable_response.return_value = True
     run_publisher = Mock()
     monkeypatch.setattr(MODULE, "run_publisher", run_publisher)
@@ -362,7 +401,7 @@ def test_definitive_rejection_blocks_without_post_or_reserve(monkeypatch):
     queue = Mock()
     client = Mock()
     client.get_existing_releases.return_value = []
-    client.check_upload_status.return_value = {"message": "Package failed validation."}
+    client.get_upload_status.return_value = {"message": "Package failed validation."}
     client._is_retryable_response.return_value = False
     run_publisher = Mock()
     outputs = {}
@@ -391,7 +430,7 @@ def test_inconclusive_status_does_not_post_or_reserve(monkeypatch, response):
     queue = Mock()
     client = Mock()
     client.get_existing_releases.return_value = []
-    client.check_upload_status.return_value = response
+    client.get_upload_status.return_value = response
     client._is_retryable_response.return_value = False
     run_publisher = Mock()
     monkeypatch.setattr(MODULE, "run_publisher", run_publisher)

--- a/.github/test_publish_workflow.py
+++ b/.github/test_publish_workflow.py
@@ -70,6 +70,8 @@ def test_queue_workflows_execute_self_contained_uv_scripts():
     assert "uv run .github/scripts/drain_splunkbase_publish_queue.py download" in publish
     assert "uv run .github/scripts/drain_splunkbase_publish_queue.py publish" in publish
     assert "uv run .github/scripts/notify_splunkbase_publish_failure.py" in publish
+    assert "uses: actions/setup-python@v5" not in publish
+    assert 'python -m pip install "uv==0.12.0"' in publish
     assert "uses: astral-sh/setup-uv" not in enqueue_workflow
     assert "uses: actions/setup-python@v5" in enqueue_workflow
     assert 'python -m pip install "uv==0.12.0"' in enqueue_workflow

--- a/.github/test_publish_workflow.py
+++ b/.github/test_publish_workflow.py
@@ -5,6 +5,8 @@ WORKFLOW = Path(__file__).parent / "workflows" / "publish.yml"
 DRAIN_WORKFLOW = Path(__file__).parent / "workflows" / "drain-splunkbase-publish-queue.yml"
 ENQUEUE_WORKFLOW = Path(__file__).parent / "workflows" / "enqueue-splunkbase-publish.yml"
 ENQUEUE_ACTION = Path(__file__).parent / "actions" / "enqueue-publish" / "action.yml"
+NOTIFY_ACTION = Path(__file__).parent / "actions" / "notify-slack" / "action.yml"
+NOTIFY_SCRIPT = Path(__file__).parent / "actions" / "notify-slack" / "notify_slack.py"
 
 
 def test_enqueue_uses_the_commit_that_created_the_artifact():
@@ -42,6 +44,16 @@ def test_skipped_direct_publish_cannot_trigger_release_slack():
 
     assert "needs.publish.result != 'skipped'" in notify
     assert "needs.publish.outputs.return_code != ''" in notify
+
+
+def test_notify_action_uses_the_explicit_connector_workspace():
+    action = NOTIFY_ACTION.read_text()
+    script = NOTIFY_SCRIPT.read_text()
+
+    assert "CONNECTOR_WORKSPACE: ${{ inputs.workspace_path }}" in action
+    assert "GITHUB_WORKSPACE: ${{ inputs.workspace_path }}" not in action
+    assert 'os.getenv("CONNECTOR_WORKSPACE"' in script
+    assert 'os.getenv("GITHUB_WORKSPACE"' in script
 
 
 def test_queue_workflows_execute_self_contained_uv_scripts():

--- a/.github/utils/api/splunkbase.py
+++ b/.github/utils/api/splunkbase.py
@@ -369,14 +369,17 @@ class Splunkbase:
             app_repo_name, package_file, url, release_notes, license_string, license_url
         )
 
+    def get_upload_status(self, package_id):
+        url = f"{self.apps_base_url}/validation/{package_id}"
+        return _get_request(url, headers=self.auth)
+
     @backoff.on_predicate(
         backoff.expo,
         _is_retryable_status_response,
         max_time=MAX_MESSAGE_RETRY_TIME,
     )
     def check_upload_status(self, package_id):
-        url = f"{self.apps_base_url}/validation/{package_id}"
-        return _get_request(url, headers=self.auth)
+        return self.get_upload_status(package_id)
 
     @staticmethod
     def get_app_id(results_dict, app_guid):

--- a/.github/utils/publish_queue.py
+++ b/.github/utils/publish_queue.py
@@ -6,6 +6,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 import json
 from typing import Any, Protocol
+from urllib.parse import quote
 
 import requests
 
@@ -223,11 +224,20 @@ class GitHubIssuePublishQueue:
         }
         for name, (color, description) in LABELS.items():
             if name not in existing:
-                self.client.request(
-                    "POST",
-                    f"{self.repo_path}/labels",
-                    json={"name": name, "color": color, "description": description},
-                )
+                try:
+                    self.client.request(
+                        "POST",
+                        f"{self.repo_path}/labels",
+                        json={"name": name, "color": color, "description": description},
+                    )
+                except RuntimeError as create_error:
+                    try:
+                        self.client.request(
+                            "GET",
+                            f"{self.repo_path}/labels/{quote(name, safe='')}",
+                        )
+                    except RuntimeError:
+                        raise create_error
 
     def _issues(self, *, state: str = "open", labels: str = QUEUE_MARKER):
         page = 1

--- a/.github/utils/test_publish_queue.py
+++ b/.github/utils/test_publish_queue.py
@@ -108,6 +108,27 @@ def test_duplicate_enqueue_reuses_one_issue():
     assert queue.get_item(first.issue_number).run_id == 456
 
 
+def test_label_creation_tolerates_another_enqueue_winning_the_race():
+    class RacingLabelClient(FakeGitHubClient):
+        def __init__(self):
+            super().__init__()
+            self.labels.clear()
+
+        def request(self, method, path, **kwargs):
+            if path.endswith("/labels") and method == "POST":
+                self.labels.add(kwargs["json"]["name"])
+                raise RuntimeError("GitHub API returned 422 already_exists")
+            if "/labels/" in path and method == "GET":
+                return {"name": path.rsplit("/", 1)[-1]}
+            return super().request(method, path, **kwargs)
+
+    client = RacingLabelClient()
+
+    GitHubIssuePublishQueue(client, "splunk-soar-connectors/.github").ensure_labels()
+
+    assert client.labels == set(LABELS)
+
+
 def test_oldest_eligible_skips_future_item():
     client = FakeGitHubClient()
     queue = GitHubIssuePublishQueue(client, "splunk-soar-connectors/.github")

--- a/.github/workflows/drain-splunkbase-publish-queue.yml
+++ b/.github/workflows/drain-splunkbase-publish-queue.yml
@@ -53,11 +53,6 @@ jobs:
       - name: Check out queue implementation
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-
       - name: Install uv
         run: python -m pip install "uv==0.12.0"
 


### PR DESCRIPTION
## Summary

- Treats a failed label-creation request as successful only when a follow-up GET confirms the label now exists.
- Uses setup-python only on GitHub-hosted queue jobs; the CodeBuild publisher bootstraps pinned uv from its existing Python runtime.
- Passes the connector checkout to release notifications through a dedicated variable instead of attempting to override GitHub workspace state.
- Starts GET-only publication verification immediately after an accepted upload, polling every 10 seconds for up to five minutes.
- Adds regression coverage for concurrent enqueues, runner-specific bootstrap, connector-workspace propagation, and verification cadence.

## Root causes

Five parallel canary dispatches read the label list before label creation completed. Four workers succeeded, while one received GitHub HTTP 422 already_exists and failed before creating its queue issue.

The first drain failed before upload because actions/setup-python cannot provision Python inside the custom CodeBuild container, which already provides the required connector Python runtime.

After Carbon Black Cloud 2.0.2 was confirmed published, its Slack notification failed because GITHUB_WORKSPACE is protected and still pointed at the central repository rather than the connector checkout.

The original verifier deferred an accepted package for five minutes before its first reconciliation. Verification now begins immediately and uses GETs every 10 seconds; the global multipart upload budget is unchanged.

The pre-upload failures made no Splunkbase upload attempts. Carbon Black Cloud used one recorded POST and then GET-only reconciliation.

## Validation

- 61 focused queue, workflow, and publisher tests passed.
- Full pre-commit suite passed, including YAML validation, Ruff, and ShellCheck.

Written by Codex.