### PR TITLE
feat: enrich app release Slack notifications

### DIFF
--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -1,5 +1,5 @@
 name: "Notify Slack on App Release"
-description: "Posts a release notification to the appropriate Slack channel"
+description: "Posts a release notification to the internal and community Slack channels"
 inputs:
   app_name:
     description: "Name of the published app"
@@ -13,6 +13,10 @@ inputs:
   release_version:
     description: "Published version"
     required: true
+  previous_release_version:
+    description: "Previously published version, empty for a first release"
+    required: false
+    default: ""
   release_notes:
     description: "JSON-encoded list of release note lines"
     required: true
@@ -58,6 +62,7 @@ runs:
         APP_LOGO: ${{ inputs.app_logo }}
         REPO_NAME: ${{ inputs.repo_name }}
         RELEASE_VERSION: ${{ inputs.release_version }}
+        PREVIOUS_RELEASE_VERSION: ${{ inputs.previous_release_version }}
         RELEASE_NOTES: ${{ inputs.release_notes }}
         NEW_APP: ${{ inputs.new_app }}
         SUPPORT_TAG: ${{ inputs.support_tag }}

--- a/.github/actions/notify-slack/notify_slack.py
+++ b/.github/actions/notify-slack/notify_slack.py
@@ -92,6 +92,8 @@ def _build_message(
     app_name,
     support_tag,
     splunk_base_url,
+    release_version,
+    previous_release_version=None,
     release_notes=None,
     new_app=False,
     template_name=RELEASE_TEMPLATE,
@@ -108,6 +110,8 @@ def _build_message(
         app_name=app_name,
         support_alias=support_alias,
         splunk_base_url=splunk_base_url,
+        release_version=release_version,
+        previous_release_version=previous_release_version,
         release_notes=_convert_release_notes_to_slack_list(release_notes),
         new_app=new_app,
     )
@@ -147,6 +151,8 @@ def _notify_slack_channel(slack_client, slack_channel, release_data):
         support_tag=release_data["support_tag"],
         release_notes=release_data["release_notes"],
         splunk_base_url=release_data["splunk_base_url"],
+        release_version=release_data["release_version"],
+        previous_release_version=release_data["previous_release_version"],
         new_app=release_data["new_app"],
         template_name=template_name,
     )
@@ -198,19 +204,18 @@ def main():
         "app_logo": os.environ["APP_LOGO"],
         "repo_name": os.environ["REPO_NAME"],
         "release_version": os.environ["RELEASE_VERSION"],
+        "previous_release_version": os.getenv("PREVIOUS_RELEASE_VERSION") or None,
         "release_notes": json.loads(os.environ["RELEASE_NOTES"]),
         "new_app": os.environ["NEW_APP"].lower() == "true",
         "support_tag": os.environ["SUPPORT_TAG"],
         "splunk_base_url": os.environ["SPLUNK_BASE_URL"],
     }
 
-    # Route: splunk-supported → internal + community channels, everything else → community only
-    if release_data["support_tag"] == "splunk":
-        _notify_slack_channel(
-            WebClient(token=os.environ["SLACK_INTERNAL_TOKEN"]),
-            os.environ["SLACK_INTERNAL_CHANNEL"],
-            release_data,
-        )
+    _notify_slack_channel(
+        WebClient(token=os.environ["SLACK_INTERNAL_TOKEN"]),
+        os.environ["SLACK_INTERNAL_CHANNEL"],
+        release_data,
+    )
 
     _notify_slack_channel(
         WebClient(token=os.environ["SLACK_COMMUNITY_TOKEN"]),

--- a/.github/actions/notify-slack/templates/release_message.txt.j2
+++ b/.github/actions/notify-slack/templates/release_message.txt.j2
@@ -2,7 +2,7 @@
 
 {% if new_app %}A new{% else %}An updated{% endif %} *{{ support_alias }}* app is now available on Splunkbase! :release:
 
-:splunk-arrow: <{{ splunk_base_url }}|*{{ app_name }}*>
+:splunk-arrow: <{{ splunk_base_url }}|*{{ app_name }}*> {% if previous_release_version %}`v{{ previous_release_version }} -> v{{ release_version }}`{% else %}`v{{ release_version }}`{% endif %}
 
 {%- for note in release_notes %}
 {{ note }}

--- a/.github/actions/notify-slack/test_notify_slack.py
+++ b/.github/actions/notify-slack/test_notify_slack.py
@@ -1,0 +1,89 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).with_name("notify_slack.py")
+SPEC = importlib.util.spec_from_file_location("notify_slack", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_updated_release_message_shows_version_transition_on_app_link():
+    message = MODULE._build_message(
+        app_name="Test App",
+        support_tag="splunk",
+        splunk_base_url="https://splunkbase.splunk.com/app/123",
+        release_version="2.0.0",
+        previous_release_version="1.2.3",
+    )
+
+    assert (
+        ":splunk-arrow: <https://splunkbase.splunk.com/app/123|*Test App*> `v1.2.3 -> v2.0.0`"
+    ) in message
+
+
+def test_release_message_without_previous_version_shows_only_new_version_on_app_link():
+    message = MODULE._build_message(
+        app_name="Test App",
+        support_tag="developer",
+        splunk_base_url="https://splunkbase.splunk.com/app/123",
+        release_version="1.0.0",
+    )
+
+    assert (":splunk-arrow: <https://splunkbase.splunk.com/app/123|*Test App*> `v1.0.0`") in message
+
+
+def test_pending_review_message_includes_release_version():
+    message = MODULE._build_message(
+        app_name="Test App",
+        support_tag="developer",
+        splunk_base_url="https://splunkbase.splunk.com/app/123",
+        release_version="1.0.0",
+        new_app=True,
+        template_name=MODULE.PENDING_REVIEW_TEMPLATE,
+    )
+
+    assert ":splunk-arrow: *Test App* v1.0.0" in message
+
+
+@pytest.mark.parametrize("support_tag", ["splunk", "developer", "not_supported"])
+def test_all_support_types_notify_internal_and_community_channels(
+    monkeypatch,
+    support_tag,
+):
+    environment = {
+        "APP_NAME": "Test App",
+        "APP_LOGO": "test.svg",
+        "REPO_NAME": "test-app",
+        "RELEASE_VERSION": "2.0.0",
+        "PREVIOUS_RELEASE_VERSION": "1.2.3",
+        "RELEASE_NOTES": "[]",
+        "NEW_APP": "false",
+        "SUPPORT_TAG": support_tag,
+        "SPLUNK_BASE_URL": "https://splunkbase.splunk.com/app/123",
+        "SLACK_INTERNAL_TOKEN": "internal-token",
+        "SLACK_COMMUNITY_TOKEN": "community-token",
+        "SLACK_INTERNAL_CHANNEL": "internal-channel",
+        "SLACK_COMMUNITY_CHANNEL": "community-channel",
+    }
+    for key, value in environment.items():
+        monkeypatch.setenv(key, value)
+
+    notifications = []
+    monkeypatch.setattr(MODULE, "WebClient", lambda token: token)
+    monkeypatch.setattr(
+        MODULE,
+        "_notify_slack_channel",
+        lambda client, channel, release_data: notifications.append(
+            (client, channel, release_data["support_tag"])
+        ),
+    )
+
+    MODULE.main()
+
+    assert notifications == [
+        ("internal-token", "internal-channel", support_tag),
+        ("community-token", "community-channel", support_tag),
+    ]

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -17,6 +17,9 @@ outputs:
   release_version:
     description: "Published version"
     value: ${{ steps.publish_app.outputs.release_version }}
+  previous_release_version:
+    description: "Previously published version, empty for a first release"
+    value: ${{ steps.publish_app.outputs.previous_release_version }}
   release_notes:
     description: "JSON-encoded list of release note lines"
     value: ${{ steps.publish_app.outputs.release_notes }}

--- a/.github/actions/publish/test_upload_to_splunkbase.py
+++ b/.github/actions/publish/test_upload_to_splunkbase.py
@@ -30,6 +30,41 @@ def test_rerun_does_not_accept_an_older_candidate():
     )
 
 
+def test_previous_release_version_uses_highest_version_below_candidate():
+    releases = [
+        {"release_name": "2.0.0"},
+        {"release_name": "1.2.3"},
+        {"release_name": "1.0.0"},
+    ]
+
+    assert MODULE.get_previous_release_version(releases, "2.0.0") == "1.2.3"
+
+
+def test_previous_release_version_is_empty_for_first_release():
+    assert MODULE.get_previous_release_version([], "1.0.0") is None
+
+
+def test_github_outputs_include_previous_release_version(tmp_path, monkeypatch):
+    output_path = tmp_path / "github-output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+
+    MODULE._write_github_outputs(
+        {
+            "name": "Test App",
+            "logo": "test.svg",
+            "app_version": "2.0.0",
+        },
+        "test-app",
+        "* Fixed behavior.",
+        new_app=False,
+        sb_appid="123",
+        support_tag="splunk",
+        previous_release_version="1.2.3",
+    )
+
+    assert "previous_release_version=1.2.3\n" in output_path.read_text()
+
+
 def test_release_notes_can_be_read_from_queued_tarball(tmp_path):
     tarball = tmp_path / "connector.tgz"
     release_notes = b"**Unreleased**\n\n* Fixed upload handling.\n"

--- a/.github/actions/publish/upload_to_splunkbase.py
+++ b/.github/actions/publish/upload_to_splunkbase.py
@@ -57,6 +57,16 @@ def is_successful_rerun_of_existing_version(candidate_version, latest_release, r
     return candidate_version == latest_release and attempt > 1
 
 
+def get_previous_release_version(existing_releases, candidate_version):
+    candidate = parse(candidate_version)
+    previous_versions = [
+        release["release_name"]
+        for release in existing_releases
+        if parse(release["release_name"]) < candidate
+    ]
+    return max(previous_versions, key=parse) if previous_versions else None
+
+
 def parse_args() -> argparse.Namespace:
     help_str = " ".join(line.strip() for line in (__doc__ or "").splitlines())
     parser = argparse.ArgumentParser(description=help_str)
@@ -146,6 +156,7 @@ def _write_github_outputs(
     new_app: bool,
     sb_appid: str,
     support_tag: str,
+    previous_release_version: Optional[str],
 ) -> None:
     github_output = os.getenv("GITHUB_OUTPUT")
     if not github_output:
@@ -160,6 +171,7 @@ def _write_github_outputs(
         f.write(f"app_logo={app_json['logo']}\n")
         f.write(f"repo_name={repo_name}\n")
         f.write(f"release_version={app_json['app_version']}\n")
+        f.write(f"previous_release_version={previous_release_version or ''}\n")
         f.write(f"new_app={'true' if new_app else 'false'}\n")
         f.write(f"support_tag={support_tag}\n")
         f.write(f"splunk_base_url={splunk_base_url}\n")
@@ -239,6 +251,7 @@ def main(args):
     )
 
     existing_releases = sb_client.get_existing_releases(appid)
+    previous_release_version = get_previous_release_version(existing_releases, app_version)
     if existing_releases:
         latest_release = max(parse(r["release_name"]) for r in existing_releases)
         logging.info("Latest released version: %s", latest_release.public)
@@ -271,6 +284,7 @@ def main(args):
                 new_app=False,
                 sb_appid=apps[0]["id"],
                 support_tag=apps[0]["support"],
+                previous_release_version=previous_release_version,
             )
             _write_publish_result(
                 "already_published",
@@ -313,6 +327,7 @@ def main(args):
         "appid": appid,
         "app_existed_before_upload": bool(apps),
         "app_name": app_json["name"],
+        "previous_release_version": previous_release_version,
         "release_version": app_version,
     }
     _write_publish_result("uploading", **publish_details)
@@ -355,6 +370,7 @@ def main(args):
             new_app=True,
             sb_appid=sb_appid,
             support_tag=support_tag,
+            previous_release_version=None,
         )
         _write_publish_result(
             "new_app",
@@ -372,6 +388,7 @@ def main(args):
         new_app=False,
         sb_appid=sb_appid,
         support_tag=apps[0]["support"],
+        previous_release_version=previous_release_version,
     )
     _write_publish_result(
         "published",

--- a/.github/scripts/drain_splunkbase_publish_queue.py
+++ b/.github/scripts/drain_splunkbase_publish_queue.py
@@ -167,6 +167,12 @@ def finalize_publication(queue, client, item, args, result, now) -> int:
             raise RuntimeError(f"Expected one Splunkbase app for {item.appid}, found {len(apps)}")
         app = apps[0]
         new_app = not result.get("app_existed_before_upload", True)
+        previous_release_version = result.get("previous_release_version")
+        if not new_app and not previous_release_version:
+            previous_release_version = publisher.get_previous_release_version(
+                client.get_existing_releases(item.appid),
+                item.candidate_version,
+            )
         if new_app:
             client.ensure_app_editors(app["id"])
 
@@ -183,6 +189,7 @@ def finalize_publication(queue, client, item, args, result, now) -> int:
         write_output("app_logo", app_json["logo"])
         write_output("repo_name", item.repository.split("/")[-1])
         write_output("release_version", item.candidate_version)
+        write_output("previous_release_version", previous_release_version or "")
         write_output("release_notes", json.dumps(release_notes.split("\n")))
         write_output("new_app", new_app)
         write_output("publish_return_code", 2 if new_app else 0)

--- a/.github/scripts/test_drain_splunkbase_publish_queue.py
+++ b/.github/scripts/test_drain_splunkbase_publish_queue.py
@@ -132,6 +132,7 @@ def test_verification_polls_every_ten_seconds_until_release_appears(monkeypatch)
         [],
         [],
         [{"release_name": "1.2.3"}],
+        [{"release_name": "1.2.3"}],
     ]
     client.get_upload_status.return_value = {"message": "Package validation still in progress."}
     client._is_retryable_response.return_value = True
@@ -515,19 +516,26 @@ def publisher_metadata():
             "get_app_json": staticmethod(lambda artifact: {"logo": "example.svg"}),
             "get_release_notes": staticmethod(lambda version, workspace: "* Fixed publication."),
             "get_release_notes_from_tarball": staticmethod(lambda artifact, version: None),
+            "get_previous_release_version": staticmethod(lambda releases, version: None),
         },
     )()
 
 
 @pytest.mark.parametrize(
-    ("existed_before", "expected_new_app", "expected_return_code"),
-    [(True, False, 0), (False, True, 2)],
+    (
+        "existed_before",
+        "expected_new_app",
+        "expected_return_code",
+        "previous_release_version",
+    ),
+    [(True, False, 0, "1.0.0"), (False, True, 2, None)],
 )
 def test_finalization_reconstructs_outputs_and_new_app_side_effects(
     monkeypatch,
     existed_before,
     expected_new_app,
     expected_return_code,
+    previous_release_version,
 ):
     queue = Mock()
     client = Mock()
@@ -540,6 +548,7 @@ def test_finalization_reconstructs_outputs_and_new_app_side_effects(
         "status": "verifying",
         "package_id": "package-123",
         "app_existed_before_upload": existed_before,
+        "previous_release_version": previous_release_version,
     }
 
     assert (
@@ -560,6 +569,7 @@ def test_finalization_reconstructs_outputs_and_new_app_side_effects(
         client.ensure_app_editors.assert_not_called()
     assert outputs["new_app"] is expected_new_app
     assert outputs["publish_return_code"] == expected_return_code
+    assert outputs["previous_release_version"] == (previous_release_version or "")
     assert outputs["support_tag"] == "splunk"
     assert outputs["splunk_base_url"] == "https://splunkbase.splunk.com/app/app-123"
     queue.complete.assert_called_once()

--- a/.github/test_publish_workflow.py
+++ b/.github/test_publish_workflow.py
@@ -56,6 +56,24 @@ def test_notify_action_uses_the_explicit_connector_workspace():
     assert 'os.getenv("GITHUB_WORKSPACE"' in script
 
 
+def test_release_version_transition_reaches_both_notification_paths():
+    workflow = WORKFLOW.read_text()
+    drain_workflow = DRAIN_WORKFLOW.read_text()
+
+    assert (
+        "previous_release_version: ${{ steps.publish_action.outputs.previous_release_version }}"
+        in workflow
+    )
+    assert (
+        "previous_release_version: ${{ needs.publish.outputs.previous_release_version }}"
+        in workflow
+    )
+    assert (
+        "previous_release_version: ${{ steps.publish.outputs.previous_release_version }}"
+        in drain_workflow
+    )
+
+
 def test_queue_workflows_execute_self_contained_uv_scripts():
     workflow = DRAIN_WORKFLOW.read_text()
     enqueue_workflow = ENQUEUE_WORKFLOW.read_text()

--- a/.github/workflows/drain-splunkbase-publish-queue.yml
+++ b/.github/workflows/drain-splunkbase-publish-queue.yml
@@ -105,6 +105,7 @@ jobs:
           app_logo: ${{ steps.publish.outputs.app_logo }}
           repo_name: ${{ steps.publish.outputs.repo_name }}
           release_version: ${{ steps.publish.outputs.release_version }}
+          previous_release_version: ${{ steps.publish.outputs.previous_release_version }}
           release_notes: ${{ steps.publish.outputs.release_notes }}
           new_app: ${{ steps.publish.outputs.new_app }}
           support_tag: ${{ steps.publish.outputs.support_tag }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -189,6 +189,7 @@ jobs:
       app_logo: ${{ steps.publish_action.outputs.app_logo }}
       repo_name: ${{ steps.publish_action.outputs.repo_name }}
       release_version: ${{ steps.publish_action.outputs.release_version }}
+      previous_release_version: ${{ steps.publish_action.outputs.previous_release_version }}
       release_notes: ${{ steps.publish_action.outputs.release_notes }}
       new_app: ${{ steps.publish_action.outputs.new_app }}
       support_tag: ${{ steps.publish_action.outputs.support_tag }}
@@ -305,6 +306,7 @@ jobs:
           app_logo: ${{ needs.publish.outputs.app_logo }}
           repo_name: ${{ needs.publish.outputs.repo_name }}
           release_version: ${{ needs.publish.outputs.release_version }}
+          previous_release_version: ${{ needs.publish.outputs.previous_release_version }}
           release_notes: ${{ needs.publish.outputs.release_notes }}
           new_app: ${{ needs.publish.outputs.new_app }}
           support_tag: ${{ needs.publish.outputs.support_tag }}


### PR DESCRIPTION
### Features

- Add previous-to-current version transitions to the Splunkbase link in app release notifications.
- Carry the previous release version through direct and queued Splunkbase publication paths.

### Bug Fixes

- Send Splunk-, developer-, and community-supported app releases to both the internal and community Slack channels.

### Manual Documentation

- [x] I have verified that no manual documentation updates are required.

### Other information

The release template now renders updated apps as `v1.2.3 -> v2.0.0` and first releases as `v1.0.0`. The queued recovery path reconstructs the previous release version for publications created before this metadata was persisted.

Validation:
- 55 focused publish, queue, workflow, and Slack notification tests passed under Python 3.13.
- `pre-commit run --all-files` passed.
- `git diff --check` passed.

PR description authored by Codex.

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!