### PR TITLE
fix: drain and diagnose Splunkbase publish queue

### DIFF
--- a/.github/SPLUNKBASE_PUBLISH_QUEUE.md
+++ b/.github/SPLUNKBASE_PUBLISH_QUEUE.md
@@ -8,10 +8,11 @@ serializes the upload POSTs made by the shared SOAR connector user.
 
 ## Safety properties
 
-The worker starts at most one upload every five minutes and no more than 12 uploads
-during the preceding hour. It records a slot before making the POST. A worker restart
-therefore cannot reset the budget. Read-only Splunkbase requests retain bounded retries,
-but multipart upload POSTs have no automatic retries.
+The worker starts at most one upload every three minutes and no more than 20 uploads
+during the preceding hour. Each run drains eligible work for at most one hour or 20
+started upload attempts, whichever comes first. It records a slot before making the
+POST. A worker restart therefore cannot reset the budget. Read-only Splunkbase requests
+retain bounded retries, but multipart upload POSTs have no automatic retries.
 
 Queue items are GitHub issues in this repository. Artifacts are uniquely named assets on
 the `splunkbase-publish-queue` prerelease. Both contain only public connector and
@@ -76,7 +77,8 @@ already has read/write workflow permissions.
 Enqueue five approved connector versions together. Verify:
 
 1. Five open issues appear with `splunkbase-publish` and `splunkbase-queued`.
-2. The state issue records no starts less than five minutes apart.
+2. The state issue records no starts less than three minutes apart and no more than 20
+   starts in any rolling hour.
 3. Each successful issue closes with `splunkbase-published`.
 4. Metrics and Slack notifications run only after the worker confirms publication.
 5. Splunkbase logs show the stable `Splunk-SOAR-Connector-Publisher/1.0` User-Agent plus
@@ -102,7 +104,9 @@ GETs; they neither reserve another upload slot nor send another multipart POST.
 Continued validation, timeouts, exhausted server-error retries, and unreadable
 responses remain in verification. The issue closes when the version appears or the
 package validates, while a definitive rejection transitions to `splunkbase-blocked`
-and fails the worker job.
+and records a failed worker result after the run finishes draining other eligible
+items. Scheduled runs are a recovery trigger; an active run waits for its next
+three-minute upload slot instead of relying on another scheduled event.
 
 To retry a corrected blocked item, preserve its JSON body, replace
 `splunkbase-blocked` with `splunkbase-queued`, and set `not_before` to the current UTC

--- a/.github/scripts/drain_splunkbase_publish_queue.py
+++ b/.github/scripts/drain_splunkbase_publish_queue.py
@@ -98,6 +98,17 @@ def retry_after_datetime(value: str | None, now: datetime) -> datetime:
             return now + MIN_ATTEMPT_INTERVAL
 
 
+def wait_for_upload_budget(queue, item, now, wait_until=None):
+    retry_at = queue.reserve_attempt(item.publisher_alias, item, now)
+    while retry_at and wait_until and retry_at < wait_until:
+        wait_seconds = max((retry_at - now).total_seconds(), 0)
+        print(f"Upload budget unavailable until {format_datetime(retry_at)}; waiting.")
+        time.sleep(wait_seconds)
+        now = utc_now()
+        retry_at = queue.reserve_attempt(item.publisher_alias, item, now)
+    return now, retry_at
+
+
 def version_exists(client: Splunkbase, appid: str, version: str) -> bool:
     return any(
         parse(str(release["release_name"])) == parse(version)
@@ -380,7 +391,12 @@ def publish_item(args) -> int:
             "Splunkbase app metadata could not be read before upload; no POST was attempted.",
         )
 
-    retry_at = queue.reserve_attempt(item.publisher_alias, item, now)
+    now, retry_at = wait_for_upload_budget(
+        queue,
+        item,
+        now,
+        getattr(args, "wait_for_budget_until", None),
+    )
     if retry_at:
         queue.requeue(
             item,
@@ -388,6 +404,7 @@ def publish_item(args) -> int:
             f"Per-user upload budget is unavailable until {format_datetime(retry_at)}.",
         )
         write_output("queue_status", "deferred")
+        write_output("not_before", format_datetime(retry_at))
         print(f"Upload budget unavailable until {format_datetime(retry_at)}.")
         return 0
 

--- a/.github/scripts/drain_splunkbase_publish_queue.py
+++ b/.github/scripts/drain_splunkbase_publish_queue.py
@@ -222,9 +222,19 @@ def defer_verification(queue, item, result, now, reason) -> int:
     return 0
 
 
+def worker_run_url() -> str | None:
+    server_url = os.getenv("GITHUB_SERVER_URL")
+    repository = os.getenv("GITHUB_REPOSITORY")
+    run_id = os.getenv("GITHUB_RUN_ID")
+    if not all((server_url, repository, run_id)):
+        return None
+    return f"{server_url.rstrip('/')}/{repository}/actions/runs/{run_id}"
+
+
 def block_publication(queue, item, result, reason, return_code=1) -> int:
     """Persist a terminal failure and expose sanitized notification fields."""
 
+    result["worker_run_url"] = worker_run_url()
     queue.block(item, result)
     write_output("publish_return_code", return_code)
     write_output("request_id", result.get("request_id", ""))

--- a/.github/scripts/drain_splunkbase_publish_queue_worker.py
+++ b/.github/scripts/drain_splunkbase_publish_queue_worker.py
@@ -1,0 +1,279 @@
+# /// script
+# requires-python = ">=3.13,<3.14"
+# dependencies = [
+#   "backoff>=2.2.1,<3.0.0",
+#   "cairosvg==2.7.0",
+#   "jinja2==3.1.5",
+#   "packaging>=24.2,<26.0",
+#   "requests>=2.32.3,<3.0.0",
+#   "slack-sdk==3.41.0",
+# ]
+# ///
+"""Drain eligible Splunkbase publications within one bounded worker run."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+import importlib.util
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+from types import SimpleNamespace
+
+
+SCRIPT_DIR = Path(__file__).parent.resolve()
+REPO_ROOT = SCRIPT_DIR.parent.resolve()
+MAX_RUN_SECONDS = 60 * 60
+MAX_UPLOAD_ATTEMPTS = 20
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+DRAIN = load_module(
+    "drain_splunkbase_publish_queue",
+    SCRIPT_DIR / "drain_splunkbase_publish_queue.py",
+)
+
+
+@dataclass
+class ItemOutcome:
+    queue_status: str
+    attempts_started: int
+    failed: bool
+
+
+def parse_outputs(path: Path) -> dict[str, str]:
+    outputs = {}
+    if not path.exists():
+        return outputs
+    for line in path.read_text().splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            outputs[key] = value
+    return outputs
+
+
+def run_checked(command: list[str], *, cwd: Path | None = None, env=None) -> None:
+    subprocess.run(command, cwd=cwd, env=env, check=True)
+
+
+def checkout_connector(repository: str, commit_sha: str, destination: Path) -> None:
+    run_checked(["git", "init", str(destination)])
+    run_checked(
+        [
+            "git",
+            "-C",
+            str(destination),
+            "remote",
+            "add",
+            "origin",
+            f"https://github.com/{repository}.git",
+        ]
+    )
+    run_checked(
+        [
+            "git",
+            "-C",
+            str(destination),
+            "fetch",
+            "--depth=2",
+            "origin",
+            commit_sha,
+        ]
+    )
+    run_checked(["git", "-C", str(destination), "checkout", "--detach", "FETCH_HEAD"])
+
+
+def send_release_metrics(outputs: dict[str, str], connector: Path, temporary: Path) -> None:
+    manifests = [
+        path
+        for path in connector.glob("*.json")
+        if not path.name.endswith(".postman_collection.json")
+    ]
+    if len(manifests) != 1:
+        raise RuntimeError(f"Expected one connector manifest, found {len(manifests)}")
+
+    old_manifest = temporary / "old-app.json"
+    previous = subprocess.run(
+        ["git", "show", f"HEAD^:{manifests[0].name}"],
+        cwd=connector,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    old_manifest.write_text(previous.stdout if previous.returncode == 0 else "{}")
+    run_checked(
+        [
+            sys.executable,
+            str(REPO_ROOT / "actions" / "metrics" / "send_metrics.py"),
+            str(manifests[0]),
+            str(old_manifest),
+            "--publish-code",
+            outputs["publish_return_code"],
+            "-t",
+            "600",
+        ]
+    )
+
+
+def send_release_notification(outputs: dict[str, str], connector: Path) -> None:
+    if os.getenv("SEND_RELEASE_MESSAGE") != "true":
+        return
+    env = os.environ.copy()
+    env.update(
+        {
+            "APP_NAME": outputs["app_name"],
+            "APP_LOGO": outputs["app_logo"],
+            "REPO_NAME": outputs["repo_name"],
+            "RELEASE_VERSION": outputs["release_version"],
+            "PREVIOUS_RELEASE_VERSION": outputs["previous_release_version"],
+            "RELEASE_NOTES": outputs["release_notes"],
+            "NEW_APP": outputs["new_app"],
+            "SUPPORT_TAG": outputs["support_tag"],
+            "SPLUNK_BASE_URL": outputs["splunk_base_url"],
+            "CONNECTOR_WORKSPACE": str(connector),
+        }
+    )
+    run_checked(
+        [
+            sys.executable,
+            str(REPO_ROOT / "actions" / "notify-slack" / "notify_slack.py"),
+        ],
+        env=env,
+    )
+
+
+def send_blocked_notification(item, outputs: dict[str, str]) -> None:
+    server_url = os.getenv("GITHUB_SERVER_URL", "https://github.com").rstrip("/")
+    env = os.environ.copy()
+    env.update(
+        {
+            "QUEUE_ISSUE_URL": (
+                f"{server_url}/{os.environ['QUEUE_REPOSITORY']}/issues/{item.issue_number}"
+            ),
+            "WORKER_RUN_URL": DRAIN.worker_run_url() or "",
+            "CONNECTOR_REPOSITORY": item.repository,
+            "CONNECTOR_VERSION": item.candidate_version,
+            "SPLUNKBASE_REQUEST_ID": outputs.get("request_id", ""),
+            "SPLUNKBASE_PACKAGE_ID": outputs.get("package_id", ""),
+            "FAILURE_REASON": outputs["failure_reason"],
+        }
+    )
+    run_checked(
+        [
+            sys.executable,
+            str(SCRIPT_DIR / "notify_splunkbase_publish_failure.py"),
+        ],
+        env=env,
+    )
+
+
+def process_item(queue, item, wait_until) -> ItemOutcome:
+    attempts_before = len(item.attempts)
+    with tempfile.TemporaryDirectory(prefix="splunkbase-publish-") as directory:
+        temporary = Path(directory)
+        artifact = temporary / item.asset_name
+        connector = temporary / "connector"
+        output_path = temporary / "github-output"
+
+        queue.download_asset(item, artifact)
+        checkout_connector(item.repository, item.commit_sha, connector)
+
+        previous_output = os.environ.get("GITHUB_OUTPUT")
+        os.environ["GITHUB_OUTPUT"] = str(output_path)
+        try:
+            return_code = DRAIN.publish_item(
+                SimpleNamespace(
+                    issue_number=item.issue_number,
+                    artifact=str(artifact),
+                    connector_workspace=str(connector),
+                    result_path=str(temporary / "publish-result.json"),
+                    publisher_output=str(temporary / "publisher-output"),
+                    wait_for_budget_until=wait_until,
+                )
+            )
+        finally:
+            if previous_output is None:
+                os.environ.pop("GITHUB_OUTPUT", None)
+            else:
+                os.environ["GITHUB_OUTPUT"] = previous_output
+
+        outputs = parse_outputs(output_path)
+        refreshed = queue.get_item(item.issue_number)
+        attempts_started = max(len(refreshed.attempts) - attempts_before, 0)
+        queue_status = outputs.get("queue_status", "failed")
+        side_effect_failed = False
+
+        try:
+            if queue_status == "published":
+                send_release_metrics(outputs, connector, temporary)
+                send_release_notification(outputs, connector)
+            elif queue_status == "blocked":
+                send_blocked_notification(item, outputs)
+        except Exception as exc:
+            side_effect_failed = True
+            print(
+                f"Post-publication side effect failed for {item.repository}: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+
+        return ItemOutcome(
+            queue_status=queue_status,
+            attempts_started=attempts_started,
+            failed=return_code != 0 or side_effect_failed,
+        )
+
+
+def drain_queue(_args) -> int:
+    started = time.monotonic()
+    wait_until = DRAIN.utc_now() + timedelta(seconds=MAX_RUN_SECONDS)
+    attempts_started = 0
+    items_processed = 0
+    had_failures = False
+
+    while (
+        time.monotonic() - started < MAX_RUN_SECONDS
+        and attempts_started < MAX_UPLOAD_ATTEMPTS
+    ):
+        queue = DRAIN.queue_from_environment()
+        item = queue.oldest_eligible("soar-connectors-default", DRAIN.utc_now())
+        if item is None:
+            print("No eligible Splunkbase publications remain.")
+            break
+
+        print(
+            f"Processing queue issue #{item.issue_number}: "
+            f"{item.repository} v{item.candidate_version}"
+        )
+        outcome = process_item(queue, item, wait_until)
+        attempts_started += outcome.attempts_started
+        items_processed += 1
+        had_failures = had_failures or outcome.failed
+
+        if outcome.queue_status in {"deferred", "rate_limited"}:
+            print(f"Stopping the drain because the global queue is {outcome.queue_status}.")
+            break
+
+    print(
+        f"Drain finished after {items_processed} item(s) and "
+        f"{attempts_started} started upload attempt(s)."
+    )
+    return 1 if had_failures else 0
+
+
+def main() -> int:
+    return drain_queue(SimpleNamespace())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/notify_splunkbase_publish_failure.py
+++ b/.github/scripts/notify_splunkbase_publish_failure.py
@@ -14,22 +14,23 @@ import requests
 
 
 def build_message(environment: dict[str, str]) -> str:
-    request_id = environment.get("SPLUNKBASE_REQUEST_ID") or "unavailable"
-    package_id = environment.get("SPLUNKBASE_PACKAGE_ID") or "unavailable"
-    return "\n".join(
+    lines = [
+        ":warning: Splunkbase connector publication blocked",
+        (f"Repository: {environment['CONNECTOR_REPOSITORY']} v{environment['CONNECTOR_VERSION']}"),
+        f"Queue item: {environment['QUEUE_ISSUE_URL']}",
+        f"Failed workflow: <{environment['WORKER_RUN_URL']}|open failed worker run>",
+    ]
+    if request_id := environment.get("SPLUNKBASE_REQUEST_ID"):
+        lines.append(f"Splunkbase request ID: {request_id}")
+    if package_id := environment.get("SPLUNKBASE_PACKAGE_ID"):
+        lines.append(f"Splunkbase package ID: {package_id}")
+    lines.extend(
         [
-            ":warning: Splunkbase connector publication blocked",
-            (
-                f"Repository: {environment['CONNECTOR_REPOSITORY']} "
-                f"v{environment['CONNECTOR_VERSION']}"
-            ),
-            f"Queue item: {environment['QUEUE_ISSUE_URL']}",
-            f"Request ID: {request_id}",
-            f"Package ID: {package_id}",
             f"Reason: {environment['FAILURE_REASON']}",
             "Automated by the Codex-authored Splunkbase publish queue.",
         ]
     )
+    return "\n".join(lines)
 
 
 def main() -> None:

--- a/.github/scripts/test_drain_splunkbase_publish_queue.py
+++ b/.github/scripts/test_drain_splunkbase_publish_queue.py
@@ -39,13 +39,56 @@ def test_worker_run_url_uses_current_actions_run(monkeypatch):
     )
 
 
+def test_worker_waits_for_budget_available_within_run_deadline(monkeypatch):
+    queue = Mock()
+    item = verifying_item()
+    now = MODULE.parse_datetime("2026-07-29T12:00:00Z")
+    retry_at = MODULE.parse_datetime("2026-07-29T12:03:00Z")
+    queue.reserve_attempt.side_effect = [retry_at, None]
+    sleep = Mock()
+    monkeypatch.setattr(MODULE.time, "sleep", sleep)
+    monkeypatch.setattr(MODULE, "utc_now", lambda: retry_at)
+
+    current, remaining_retry = MODULE.wait_for_upload_budget(
+        queue,
+        item,
+        now,
+        MODULE.parse_datetime("2026-07-29T13:00:00Z"),
+    )
+
+    assert current == retry_at
+    assert remaining_retry is None
+    sleep.assert_called_once_with(180)
+
+
+def test_worker_does_not_wait_past_run_deadline(monkeypatch):
+    queue = Mock()
+    item = verifying_item()
+    now = MODULE.parse_datetime("2026-07-29T12:59:00Z")
+    retry_at = MODULE.parse_datetime("2026-07-29T13:02:00Z")
+    queue.reserve_attempt.return_value = retry_at
+    sleep = Mock()
+    monkeypatch.setattr(MODULE.time, "sleep", sleep)
+
+    current, remaining_retry = MODULE.wait_for_upload_budget(
+        queue,
+        item,
+        now,
+        MODULE.parse_datetime("2026-07-29T13:00:00Z"),
+    )
+
+    assert current == now
+    assert remaining_retry == retry_at
+    sleep.assert_not_called()
+
+
 def test_simulation_deduplicates_and_respects_hourly_budget(tmp_path, capsys):
     queue = [
         {
             "repository": f"splunk-soar-connectors/repo-{index:02}",
             "candidate_version": "1.0.0",
         }
-        for index in range(13)
+        for index in range(21)
     ]
     queue.append(queue[0])
     queue_file = tmp_path / "queue.json"
@@ -63,10 +106,10 @@ def test_simulation_deduplicates_and_respects_hourly_budget(tmp_path, capsys):
     assert MODULE.simulate(args) == 0
 
     lines = capsys.readouterr().out.splitlines()
-    assert len(lines) == 13
+    assert len(lines) == 21
     assert lines[0].endswith("2026-07-29T12:00:00Z")
-    assert lines[11].endswith("2026-07-29T12:55:00Z")
-    assert lines[12].endswith("2026-07-29T13:00:00Z")
+    assert lines[19].endswith("2026-07-29T12:57:00Z")
+    assert lines[20].endswith("2026-07-29T13:00:00Z")
 
 
 def verifying_item():

--- a/.github/scripts/test_drain_splunkbase_publish_queue.py
+++ b/.github/scripts/test_drain_splunkbase_publish_queue.py
@@ -29,6 +29,16 @@ def test_retry_after_supports_seconds_and_http_dates():
     )
 
 
+def test_worker_run_url_uses_current_actions_run(monkeypatch):
+    monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.example.com/")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "splunk-soar-connectors/.github")
+    monkeypatch.setenv("GITHUB_RUN_ID", "12345")
+
+    assert MODULE.worker_run_url() == (
+        "https://github.example.com/splunk-soar-connectors/.github/actions/runs/12345"
+    )
+
+
 def test_simulation_deduplicates_and_respects_hourly_budget(tmp_path, capsys):
     queue = [
         {

--- a/.github/scripts/test_drain_splunkbase_publish_queue_worker.py
+++ b/.github/scripts/test_drain_splunkbase_publish_queue_worker.py
@@ -1,0 +1,188 @@
+import importlib.util
+import os
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+
+MODULE_PATH = Path(__file__).with_name("drain_splunkbase_publish_queue_worker.py")
+SPEC = importlib.util.spec_from_file_location(
+    "drain_splunkbase_publish_queue_worker",
+    MODULE_PATH,
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def queue_with_items(count):
+    queue = Mock()
+    items = [
+        SimpleNamespace(
+            attempts=[],
+            candidate_version="1.0.0",
+            issue_number=index + 1,
+            repository=f"splunk-soar-connectors/example-{index + 1}",
+        )
+        for index in range(count)
+    ]
+    queue.oldest_eligible.side_effect = [*items, None]
+    return queue
+
+
+def test_drain_stops_after_twenty_started_upload_attempts(monkeypatch):
+    queue = queue_with_items(MODULE.MAX_UPLOAD_ATTEMPTS + 1)
+    process_item = Mock(
+        return_value=MODULE.ItemOutcome(
+            queue_status="published",
+            attempts_started=1,
+            failed=False,
+        )
+    )
+    monkeypatch.setattr(MODULE.DRAIN, "queue_from_environment", lambda: queue)
+    monkeypatch.setattr(MODULE, "process_item", process_item)
+    monkeypatch.setattr(MODULE.time, "monotonic", lambda: 0)
+
+    assert MODULE.drain_queue(SimpleNamespace()) == 0
+
+    assert process_item.call_count == MODULE.MAX_UPLOAD_ATTEMPTS
+
+
+def test_pre_upload_failures_do_not_consume_attempt_limit(monkeypatch):
+    queue = queue_with_items(MODULE.MAX_UPLOAD_ATTEMPTS + 1)
+    process_item = Mock(
+        return_value=MODULE.ItemOutcome(
+            queue_status="blocked",
+            attempts_started=0,
+            failed=True,
+        )
+    )
+    monkeypatch.setattr(MODULE.DRAIN, "queue_from_environment", lambda: queue)
+    monkeypatch.setattr(MODULE, "process_item", process_item)
+    monkeypatch.setattr(MODULE.time, "monotonic", lambda: 0)
+
+    assert MODULE.drain_queue(SimpleNamespace()) == 1
+
+    assert process_item.call_count == MODULE.MAX_UPLOAD_ATTEMPTS + 1
+
+
+def test_drain_stops_selecting_after_one_hour(monkeypatch):
+    queue = queue_with_items(2)
+    process_item = Mock(
+        return_value=MODULE.ItemOutcome(
+            queue_status="blocked",
+            attempts_started=0,
+            failed=True,
+        )
+    )
+    clock = iter([0, 0, MODULE.MAX_RUN_SECONDS])
+    monkeypatch.setattr(MODULE.DRAIN, "queue_from_environment", lambda: queue)
+    monkeypatch.setattr(MODULE, "process_item", process_item)
+    monkeypatch.setattr(MODULE.time, "monotonic", lambda: next(clock))
+
+    assert MODULE.drain_queue(SimpleNamespace()) == 1
+
+    process_item.assert_called_once()
+
+
+def test_rate_limit_stops_the_current_drain(monkeypatch):
+    queue = queue_with_items(2)
+    process_item = Mock(
+        return_value=MODULE.ItemOutcome(
+            queue_status="rate_limited",
+            attempts_started=1,
+            failed=False,
+        )
+    )
+    monkeypatch.setattr(MODULE.DRAIN, "queue_from_environment", lambda: queue)
+    monkeypatch.setattr(MODULE, "process_item", process_item)
+    monkeypatch.setattr(MODULE.time, "monotonic", lambda: 0)
+
+    assert MODULE.drain_queue(SimpleNamespace()) == 0
+
+    process_item.assert_called_once()
+
+
+def test_process_item_counts_attempt_and_sends_blocked_notification(tmp_path, monkeypatch):
+    item = SimpleNamespace(
+        app_name="Example",
+        appid="example-guid",
+        artifact_name="app-tar",
+        asset_name="example.tgz",
+        attempts=[],
+        candidate_version="1.0.0",
+        commit_sha="abc123",
+        issue_number=1,
+        publisher_alias="soar-connectors-default",
+        release_tag="splunkbase-publish-queue",
+        repository="splunk-soar-connectors/example",
+        run_attempt=1,
+        run_id=123,
+    )
+    refreshed = SimpleNamespace(attempts=[{"outcome": "started"}])
+    queue = Mock()
+    queue.get_item.return_value = refreshed
+    blocked_notification = Mock()
+
+    def publish_item(_args):
+        Path(os.environ["GITHUB_OUTPUT"]).write_text(
+            "queue_status=blocked\nfailure_reason=terminal failure\n"
+        )
+        return 1
+
+    monkeypatch.setattr(MODULE, "checkout_connector", Mock())
+    monkeypatch.setattr(MODULE.DRAIN, "publish_item", publish_item)
+    monkeypatch.setattr(MODULE, "send_blocked_notification", blocked_notification)
+
+    outcome = MODULE.process_item(queue, item, MODULE.DRAIN.utc_now())
+
+    assert outcome == MODULE.ItemOutcome(
+        queue_status="blocked",
+        attempts_started=1,
+        failed=True,
+    )
+    blocked_notification.assert_called_once()
+
+
+def test_process_item_preserves_success_metrics_and_notification(monkeypatch):
+    item = SimpleNamespace(
+        app_name="Example",
+        appid="example-guid",
+        artifact_name="app-tar",
+        asset_name="example.tgz",
+        attempts=[],
+        candidate_version="1.0.0",
+        commit_sha="abc123",
+        issue_number=1,
+        publisher_alias="soar-connectors-default",
+        release_tag="splunkbase-publish-queue",
+        repository="splunk-soar-connectors/example",
+        run_attempt=1,
+        run_id=123,
+    )
+    queue = Mock()
+    queue.get_item.return_value = SimpleNamespace(attempts=[{"outcome": "published"}])
+    metrics = Mock()
+    notification = Mock()
+
+    def publish_item(_args):
+        Path(os.environ["GITHUB_OUTPUT"]).write_text(
+            "queue_status=published\npublish_return_code=0\n"
+        )
+        return 0
+
+    monkeypatch.setattr(MODULE, "checkout_connector", Mock())
+    monkeypatch.setattr(MODULE.DRAIN, "publish_item", publish_item)
+    monkeypatch.setattr(MODULE, "send_release_metrics", metrics)
+    monkeypatch.setattr(MODULE, "send_release_notification", notification)
+
+    outcome = MODULE.process_item(queue, item, MODULE.DRAIN.utc_now())
+
+    assert outcome == MODULE.ItemOutcome(
+        queue_status="published",
+        attempts_started=1,
+        failed=False,
+    )
+    metrics.assert_called_once()
+    notification.assert_called_once()

--- a/.github/scripts/test_notify_splunkbase_publish_failure.py
+++ b/.github/scripts/test_notify_splunkbase_publish_failure.py
@@ -14,6 +14,7 @@ def environment(**overrides):
         "SLACK_INTERNAL_TOKEN": "token",
         "SLACK_INTERNAL_CHANNEL": "C123",
         "QUEUE_ISSUE_URL": "https://github.com/splunk-soar-connectors/.github/issues/10",
+        "WORKER_RUN_URL": ("https://github.com/splunk-soar-connectors/.github/actions/runs/12345"),
         "CONNECTOR_REPOSITORY": "splunk-soar-connectors/example",
         "CONNECTOR_VERSION": "1.2.3",
         "SPLUNKBASE_REQUEST_ID": "request-123",
@@ -31,7 +32,20 @@ def test_message_contains_tracking_fields_and_codex_attribution():
     assert "request-123" in message
     assert "package-123" in message
     assert "/issues/10" in message
+    assert (
+        "Failed workflow: "
+        "<https://github.com/splunk-soar-connectors/.github/actions/runs/12345"
+        "|open failed worker run>"
+    ) in message
     assert "Codex-authored" in message
+
+
+def test_message_omits_splunkbase_ids_before_an_upload():
+    message = MODULE.build_message(environment(SPLUNKBASE_REQUEST_ID="", SPLUNKBASE_PACKAGE_ID=""))
+
+    assert "request ID" not in message
+    assert "package ID" not in message
+    assert "unavailable" not in message
 
 
 def test_main_posts_one_internal_notification(monkeypatch):

--- a/.github/test_publish_workflow.py
+++ b/.github/test_publish_workflow.py
@@ -7,6 +7,7 @@ ENQUEUE_WORKFLOW = Path(__file__).parent / "workflows" / "enqueue-splunkbase-pub
 ENQUEUE_ACTION = Path(__file__).parent / "actions" / "enqueue-publish" / "action.yml"
 NOTIFY_ACTION = Path(__file__).parent / "actions" / "notify-slack" / "action.yml"
 NOTIFY_SCRIPT = Path(__file__).parent / "actions" / "notify-slack" / "notify_slack.py"
+QUEUE_WORKER = Path(__file__).parent / "scripts" / "drain_splunkbase_publish_queue_worker.py"
 
 
 def test_enqueue_uses_the_commit_that_created_the_artifact():
@@ -21,21 +22,27 @@ def test_enqueue_uses_the_commit_that_created_the_artifact():
 
 
 def test_drain_notifies_internal_slack_only_for_terminal_blocked_items():
-    workflow = DRAIN_WORKFLOW.read_text()
-    notification = workflow.split(
-        "\n      - name: Notify internal Slack of blocked publication\n",
-        1,
-    )[1]
+    worker = QUEUE_WORKER.read_text()
 
-    assert "if: always() && steps.publish.outputs.queue_status == 'blocked'" in notification
-    assert "SLACK_INTERNAL_TOKEN: ${{ secrets.SLACK_INTERNAL_TOKEN }}" in notification
-    assert "QUEUE_ISSUE_URL:" in notification
-    assert "SPLUNKBASE_REQUEST_ID:" in notification
-    assert "SPLUNKBASE_PACKAGE_ID:" in notification
-    assert "FAILURE_REASON:" in notification
-    assert "queue_status == 'verifying'" not in notification
-    assert "queue_status == 'deferred'" not in notification
-    assert "queue_status == 'rate_limited'" not in notification
+    assert 'elif queue_status == "blocked":' in worker
+    assert "send_blocked_notification(item, outputs)" in worker
+    assert '"QUEUE_ISSUE_URL":' in worker
+    assert '"SPLUNKBASE_REQUEST_ID":' in worker
+    assert '"SPLUNKBASE_PACKAGE_ID":' in worker
+    assert '"FAILURE_REASON":' in worker
+    assert 'queue_status == "verifying"' not in worker
+    assert 'queue_status == "deferred"' not in worker
+    assert 'queue_status == "rate_limited"' not in worker
+
+
+def test_drain_is_bounded_to_one_hour_and_twenty_upload_attempts():
+    workflow = DRAIN_WORKFLOW.read_text()
+    worker = QUEUE_WORKER.read_text()
+
+    assert "timeout-minutes: 60" in workflow
+    assert "MAX_RUN_SECONDS = 60 * 60" in worker
+    assert "MAX_UPLOAD_ATTEMPTS = 20" in worker
+    assert "attempts_started < MAX_UPLOAD_ATTEMPTS" in worker
 
 
 def test_skipped_direct_publish_cannot_trigger_release_slack():
@@ -58,7 +65,6 @@ def test_notify_action_uses_the_explicit_connector_workspace():
 
 def test_release_version_transition_reaches_both_notification_paths():
     workflow = WORKFLOW.read_text()
-    drain_workflow = DRAIN_WORKFLOW.read_text()
 
     assert (
         "previous_release_version: ${{ steps.publish_action.outputs.previous_release_version }}"
@@ -69,8 +75,8 @@ def test_release_version_transition_reaches_both_notification_paths():
         in workflow
     )
     assert (
-        "previous_release_version: ${{ steps.publish.outputs.previous_release_version }}"
-        in drain_workflow
+        '"PREVIOUS_RELEASE_VERSION": outputs["previous_release_version"]'
+        in QUEUE_WORKER.read_text()
     )
 
 
@@ -78,11 +84,10 @@ def test_queue_workflows_execute_self_contained_uv_scripts():
     workflow = DRAIN_WORKFLOW.read_text()
     enqueue_workflow = ENQUEUE_WORKFLOW.read_text()
     enqueue_action = ENQUEUE_ACTION.read_text()
-    select = workflow.split("\n  select:\n", 1)[1].split("\n  publish-one:\n", 1)[0]
-    publish = workflow.split("\n  publish-one:\n", 1)[1]
     drain_script = (
         Path(__file__).parent / "scripts" / "drain_splunkbase_publish_queue.py"
     ).read_text()
+    worker_script = QUEUE_WORKER.read_text()
     enqueue_script = (
         Path(__file__).parent / "scripts" / "enqueue_splunkbase_publish.py"
     ).read_text()
@@ -94,14 +99,9 @@ def test_queue_workflows_execute_self_contained_uv_scripts():
     ).read_text()
 
     assert "uses: astral-sh/setup-uv" not in workflow
-    assert "uses: actions/setup-python@v5" in select
-    assert 'python -m pip install "uv==0.12.0"' in select
-    assert "uv run .github/scripts/drain_splunkbase_publish_queue.py select" in select
-    assert "uv run .github/scripts/drain_splunkbase_publish_queue.py download" in publish
-    assert "uv run .github/scripts/drain_splunkbase_publish_queue.py publish" in publish
-    assert "uv run .github/scripts/notify_splunkbase_publish_failure.py" in publish
-    assert "uses: actions/setup-python@v5" not in publish
-    assert 'python -m pip install "uv==0.12.0"' in publish
+    assert "uses: actions/setup-python@v5" not in workflow
+    assert 'python -m pip install "uv==0.12.0"' in workflow
+    assert "uv run .github/scripts/drain_splunkbase_publish_queue_worker.py" in workflow
     assert "uses: astral-sh/setup-uv" not in enqueue_workflow
     assert "uses: actions/setup-python@v5" in enqueue_workflow
     assert 'python -m pip install "uv==0.12.0"' in enqueue_workflow
@@ -110,13 +110,11 @@ def test_queue_workflows_execute_self_contained_uv_scripts():
     assert "uses: actions/setup-python@v5" in enqueue_action
     assert 'python -m pip install "uv==0.12.0"' in enqueue_action
     assert 'uv run "${{ github.action_path }}/prepare_enqueue.py"' in enqueue_action
-    assert "pip install -r" not in select
-    assert "backoff" not in select
-    assert "packaging" not in select
-    assert "requests" not in select
     assert '"backoff>=2.2.1,<3.0.0"' in drain_script
     assert '"requests>=2.32.3,<3.0.0"' in drain_script
     assert '"packaging>=24.2,<26.0"' in drain_script
+    assert '"cairosvg==2.7.0"' in worker_script
+    assert '"slack-sdk==3.41.0"' in worker_script
     assert '"requests>=2.32.3,<3.0.0"' in enqueue_script
     assert "dependencies = []" in prepare_script
     assert '"requests>=2.32.3,<3.0.0"' in notify_script

--- a/.github/utils/publish_queue.py
+++ b/.github/utils/publish_queue.py
@@ -48,6 +48,7 @@ PUBLIC_RESULT_FIELDS = {
     "release_version",
     "package_id",
     "splunkbase_app_id",
+    "worker_run_url",
 }
 
 
@@ -440,10 +441,17 @@ class GitHubIssuePublishQueue:
             item.attempts[-1].update(public_result)
         else:
             item.attempts.append(public_result)
+        worker_run_url = public_result.get("worker_run_url")
+        note = "Publication stopped without an automatic retry; inspect the worker log."
+        if worker_run_url:
+            note = (
+                "Publication stopped without an automatic retry; inspect the "
+                f"[failed worker run]({worker_run_url})."
+            )
         self._update(
             item,
             state="blocked",
-            note="Publication stopped without an automatic retry; inspect the worker log.",
+            note=note,
         )
 
     def _state_issue(self, publisher_alias: str):

--- a/.github/utils/publish_queue.py
+++ b/.github/utils/publish_queue.py
@@ -23,8 +23,8 @@ QUEUE_STATES = {
 STATE_LABEL = "splunkbase-publish-state"
 BODY_START = "<!-- splunkbase-publish-queue-json"
 BODY_END = "splunkbase-publish-queue-json -->"
-MAX_ATTEMPTS_PER_HOUR = 12
-MIN_ATTEMPT_INTERVAL = timedelta(minutes=5)
+MAX_ATTEMPTS_PER_HOUR = 20
+MIN_ATTEMPT_INTERVAL = timedelta(minutes=3)
 
 LABELS = {
     QUEUE_MARKER: ("5319e7", "Managed by Codex-authored Splunkbase queue automation."),

--- a/.github/utils/test_publish_queue.py
+++ b/.github/utils/test_publish_queue.py
@@ -254,6 +254,9 @@ def test_blocked_issue_does_not_publish_raw_response_text():
             "status": "validation_failed",
             "status_code": 422,
             "request_id": "request-123",
+            "worker_run_url": (
+                "https://github.com/splunk-soar-connectors/.github/actions/runs/12345"
+            ),
             "message": "internal Splunkbase response details",
         },
     )
@@ -261,4 +264,7 @@ def test_blocked_issue_does_not_publish_raw_response_text():
     body = client.issues[0]["body"]
     assert "validation_failed" in body
     assert "request-123" in body
+    assert (
+        "[failed worker run](https://github.com/splunk-soar-connectors/.github/actions/runs/12345)"
+    ) in body
     assert "internal Splunkbase response details" not in body

--- a/.github/utils/test_publish_queue.py
+++ b/.github/utils/test_publish_queue.py
@@ -199,7 +199,7 @@ def test_verifying_item_is_selected_without_becoming_queued():
     ]
 
 
-def test_rate_ledger_never_reserves_more_than_twelve_in_a_rolling_hour():
+def test_rate_ledger_never_reserves_more_than_twenty_in_a_rolling_hour():
     client = FakeGitHubClient()
     queue = GitHubIssuePublishQueue(client, "splunk-soar-connectors/.github")
     item = queue.enqueue(make_item())

--- a/.github/workflows/drain-splunkbase-publish-queue.yml
+++ b/.github/workflows/drain-splunkbase-publish-queue.yml
@@ -122,6 +122,7 @@ jobs:
           SLACK_INTERNAL_TOKEN: ${{ secrets.SLACK_INTERNAL_TOKEN }}
           SLACK_INTERNAL_CHANNEL: ${{ vars.SLACK_INTERNAL_CHANNEL_ID }}
           QUEUE_ISSUE_URL: https://github.com/${{ github.repository }}/issues/${{ needs.select.outputs.issue_number }}
+          WORKER_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           CONNECTOR_REPOSITORY: ${{ needs.select.outputs.repository }}
           CONNECTOR_VERSION: ${{ needs.select.outputs.candidate_version }}
           SPLUNKBASE_REQUEST_ID: ${{ steps.publish.outputs.request_id }}

--- a/.github/workflows/drain-splunkbase-publish-queue.yml
+++ b/.github/workflows/drain-splunkbase-publish-queue.yml
@@ -14,38 +14,9 @@ permissions:
   issues: write
 
 jobs:
-  select:
+  drain:
     if: vars.SPLUNKBASE_PUBLISH_QUEUE_ENABLED == 'true'
-    runs-on: ubuntu-latest
-    outputs:
-      has_item: ${{ steps.select.outputs.has_item }}
-      issue_number: ${{ steps.select.outputs.issue_number }}
-      repository: ${{ steps.select.outputs.repository }}
-      commit_sha: ${{ steps.select.outputs.commit_sha }}
-      asset_name: ${{ steps.select.outputs.asset_name }}
-      candidate_version: ${{ steps.select.outputs.candidate_version }}
-    steps:
-      - name: Check out queue implementation
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-
-      - name: Install uv
-        run: python -m pip install "uv==0.12.0"
-
-      - name: Select oldest eligible publication
-        id: select
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          QUEUE_REPOSITORY: ${{ github.repository }}
-        run: uv run .github/scripts/drain_splunkbase_publish_queue.py select
-
-  publish-one:
-    needs: select
-    if: needs.select.outputs.has_item == 'true'
+    timeout-minutes: 60
     runs-on:
       - codebuild-integration-tests-${{ github.run_id }}-${{ github.run_attempt }}
       - image:custom-linux-875003031410.dkr.ecr.us-west-2.amazonaws.com/soar-connectors/pytest:f7150dbb7f347d35f8f4bb285d36985ecd4cf231
@@ -53,79 +24,25 @@ jobs:
       - name: Check out queue implementation
         uses: actions/checkout@v4
 
-      - name: Install uv
-        run: python -m pip install "uv==0.12.0"
-
-      - name: Download immutable connector artifact
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          QUEUE_REPOSITORY: ${{ github.repository }}
+      - name: Install worker dependencies
         run: |
-          mkdir -p "$RUNNER_TEMP/splunkbase-artifact"
-          uv run .github/scripts/drain_splunkbase_publish_queue.py download \
-            --issue-number "${{ needs.select.outputs.issue_number }}" \
-            --output "$RUNNER_TEMP/splunkbase-artifact/${{ needs.select.outputs.asset_name }}"
+          python -m pip install "uv==0.12.0"
+          if command -v yum >/dev/null 2>&1; then
+            yum install -y cairo
+          else
+            apt-get update
+            apt-get install -y libcairo2
+          fi
 
-      - name: Check out connector release
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ needs.select.outputs.repository }}
-          ref: ${{ needs.select.outputs.commit_sha }}
-          fetch-depth: 2
-          path: connector
-          persist-credentials: false
-
-      - name: Publish one queued connector
-        id: publish
+      - name: Drain queued connector publications
         env:
           GITHUB_TOKEN: ${{ github.token }}
           QUEUE_REPOSITORY: ${{ github.repository }}
           SPLUNKBASE_USER: ${{ secrets.SPLUNKBASE_USER }}
           SPLUNKBASE_PASSWORD: ${{ secrets.SPLUNKBASE_PASSWORD }}
-        run: |
-          uv run .github/scripts/drain_splunkbase_publish_queue.py publish \
-            --issue-number "${{ needs.select.outputs.issue_number }}" \
-            --artifact "$RUNNER_TEMP/splunkbase-artifact/${{ needs.select.outputs.asset_name }}" \
-            --connector-workspace "${{ github.workspace }}/connector" \
-            --result-path "$RUNNER_TEMP/splunkbase-publish-result.json" \
-            --publisher-output "$RUNNER_TEMP/splunkbase-publisher-output"
-
-      - name: Send release metrics
-        if: steps.publish.outputs.queue_status == 'published'
-        uses: ./.github/actions/metrics
-        with:
-          publish_return_code: ${{ steps.publish.outputs.publish_return_code }}
-          repo_path: ${{ github.workspace }}/connector
-
-      - name: Notify Slack
-        if: steps.publish.outputs.queue_status == 'published' && vars.SEND_RELEASE_MESSAGE == 'true'
-        uses: ./.github/actions/notify-slack
-        with:
-          app_name: ${{ steps.publish.outputs.app_name }}
-          app_logo: ${{ steps.publish.outputs.app_logo }}
-          repo_name: ${{ steps.publish.outputs.repo_name }}
-          release_version: ${{ steps.publish.outputs.release_version }}
-          previous_release_version: ${{ steps.publish.outputs.previous_release_version }}
-          release_notes: ${{ steps.publish.outputs.release_notes }}
-          new_app: ${{ steps.publish.outputs.new_app }}
-          support_tag: ${{ steps.publish.outputs.support_tag }}
-          splunk_base_url: ${{ steps.publish.outputs.splunk_base_url }}
-          workspace_path: ${{ github.workspace }}/connector
-          slack_internal_token: ${{ secrets.SLACK_INTERNAL_TOKEN }}
-          slack_community_token: ${{ secrets.SLACK_COMMUNITY_TOKEN }}
-          slack_internal_channel: ${{ vars.SLACK_INTERNAL_CHANNEL_ID }}
-          slack_community_channel: ${{ vars.SLACK_COMMUNITY_CHANNEL_ID }}
-
-      - name: Notify internal Slack of blocked publication
-        if: always() && steps.publish.outputs.queue_status == 'blocked'
-        env:
           SLACK_INTERNAL_TOKEN: ${{ secrets.SLACK_INTERNAL_TOKEN }}
+          SLACK_COMMUNITY_TOKEN: ${{ secrets.SLACK_COMMUNITY_TOKEN }}
           SLACK_INTERNAL_CHANNEL: ${{ vars.SLACK_INTERNAL_CHANNEL_ID }}
-          QUEUE_ISSUE_URL: https://github.com/${{ github.repository }}/issues/${{ needs.select.outputs.issue_number }}
-          WORKER_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          CONNECTOR_REPOSITORY: ${{ needs.select.outputs.repository }}
-          CONNECTOR_VERSION: ${{ needs.select.outputs.candidate_version }}
-          SPLUNKBASE_REQUEST_ID: ${{ steps.publish.outputs.request_id }}
-          SPLUNKBASE_PACKAGE_ID: ${{ steps.publish.outputs.package_id }}
-          FAILURE_REASON: ${{ steps.publish.outputs.failure_reason }}
-        run: uv run .github/scripts/notify_splunkbase_publish_failure.py
+          SLACK_COMMUNITY_CHANNEL: ${{ vars.SLACK_COMMUNITY_CHANNEL_ID }}
+          SEND_RELEASE_MESSAGE: ${{ vars.SEND_RELEASE_MESSAGE }}
+        run: uv run .github/scripts/drain_splunkbase_publish_queue_worker.py


### PR DESCRIPTION
Authored by Codex.

## What changed

- drain eligible publications within one workflow run instead of processing one item per scheduled event
- cap each run at 60 minutes and 20 started upload attempts
- enforce the shared user's 20-attempt rolling-hour budget with at least three minutes between POST starts
- continue past terminal and pre-upload failures without counting failures that never started an upload
- stop the drain on Splunkbase rate limiting and preserve `Retry-After`
- capture the current GitHub Actions worker-run URL when a publication becomes blocked
- persist that URL in sanitized queue attempt metadata
- render a direct `failed worker run` link in the queue issue status note
- link Slack failure warnings to the same worker run
- show Splunkbase request and package IDs only when Splunkbase supplied them

## Why

The previous worker processed exactly one item per scheduled run. GitHub's best-effort schedule was producing runs roughly every 30–40 minutes despite a five-minute cron, so one blocked publication left eligible work idle until another run appeared. The bounded worker now drains available work itself while the durable rate ledger remains the upload gate; scheduled runs become a recovery trigger.

Queue issue #437 and its Slack warning also demonstrated the diagnostic gap. That publication failed a local version check before upload, so no Splunkbase request or package identifiers existed; displaying both as `unavailable` added noise without helping diagnosis.

## Validation

- repository pytest excluding only the unchanged success-Slack test that requires native Cairo locally — 104 passed, 3 subtests passed
- `pre-commit run --all-files` — passed
- the focused queue/workflow suite covers the one-hour and 20-attempt caps, rolling quota, three-minute spacing, pre-upload failures, terminal blocks, rate limiting, recovery, and notification routing
