### PR TITLE
fix: surface Splunkbase publisher failures

### DIFF
--- a/.github/actions/enqueue-publish/action.yml
+++ b/.github/actions/enqueue-publish/action.yml
@@ -69,7 +69,7 @@ runs:
               --target main \
               --prerelease \
               --title "Splunkbase publish queue" \
-              --notes "Operational artifact storage managed by Codex-authored automation." \
+              --notes "Operational artifact storage managed by Splunkbase queue automation." \
               2>"$create_log"; then
             release_visible=false
             for delay in 1 2 3 4 5; do

--- a/.github/actions/publish/test_upload_to_splunkbase.py
+++ b/.github/actions/publish/test_upload_to_splunkbase.py
@@ -7,6 +7,7 @@ import tarfile
 from packaging.version import parse
 import pytest
 import requests
+from unittest.mock import Mock
 
 
 MODULE_PATH = Path(__file__).with_name("upload_to_splunkbase.py")
@@ -15,6 +16,21 @@ MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 
 from utils.api.splunkbase import build_user_agent
+
+
+def test_logging_uses_only_time_level_and_message(monkeypatch):
+    basic_config = Mock()
+    monkeypatch.setattr(MODULE.logging, "basicConfig", basic_config)
+
+    MODULE.configure_logging()
+
+    basic_config.assert_called_once_with(
+        level=MODULE.logging.INFO,
+        format="{asctime} - {levelname} - {message}",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        style="{",
+        force=True,
+    )
 
 
 def test_existing_version_is_only_successful_on_rerun():

--- a/.github/actions/publish/test_upload_to_splunkbase.py
+++ b/.github/actions/publish/test_upload_to_splunkbase.py
@@ -98,6 +98,19 @@ def test_structured_rate_limit_result_is_written(tmp_path, monkeypatch):
     }
 
 
+def test_terminal_failure_persists_public_safe_diagnostic(tmp_path, monkeypatch):
+    result_path = tmp_path / "publish-result.json"
+    monkeypatch.setattr(MODULE, "PUBLISH_RESULT_PATH", str(result_path))
+
+    reason = "Candidate version 1.0.0 must be greater than the latest released version 1.0.0."
+
+    assert MODULE._fail(reason) == MODULE.RESULT_CODES["failed"]
+    assert json.loads(result_path.read_text()) == {
+        "failure_reason": reason,
+        "status": "failed",
+    }
+
+
 @pytest.mark.parametrize(
     "validation_error",
     [
@@ -188,6 +201,23 @@ def test_unexpected_failure_preserves_written_verification_result(tmp_path, monk
 
     assert MODULE.cli() == MODULE.RESULT_CODES["verifying"]
     assert json.loads(result_path.read_text()) == result
+
+
+def test_unexpected_pre_upload_failure_persists_safe_diagnostic(tmp_path, monkeypatch):
+    result_path = tmp_path / "publish-result.json"
+    monkeypatch.setattr(MODULE, "PUBLISH_RESULT_PATH", str(result_path))
+    monkeypatch.setattr(MODULE, "parse_args", lambda: object())
+    monkeypatch.setattr(
+        MODULE,
+        "main",
+        lambda args: (_ for _ in ()).throw(RuntimeError("secret response text")),
+    )
+
+    assert MODULE.cli() == MODULE.RESULT_CODES["failed"]
+    assert json.loads(result_path.read_text()) == {
+        "failure_reason": "The publisher raised an unexpected error before completing.",
+        "status": "failed",
+    }
 
 
 def test_accepted_upload_persists_package_metadata_before_failed_status_get(

--- a/.github/actions/publish/upload_to_splunkbase.py
+++ b/.github/actions/publish/upload_to_splunkbase.py
@@ -191,6 +191,14 @@ def _write_publish_result(status: str, **details: Any) -> None:
     Path(PUBLISH_RESULT_PATH).write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
 
 
+def _fail(reason: str) -> int:
+    """Persist a controlled, public-safe diagnostic for a terminal failure."""
+
+    logging.error(reason)
+    _write_publish_result("failed", failure_reason=reason)
+    return RESULT_CODES["failed"]
+
+
 def _existing_publish_result() -> dict[str, Any]:
     if not PUBLISH_RESULT_PATH:
         return {}
@@ -264,18 +272,16 @@ def main(args):
             )
             apps = sb_client.get_apps({"appid": appid})
             if not apps:
-                logging.error(
-                    "Could not find Splunkbase app metadata for existing version %s", app_version
+                return _fail(
+                    f"Splunkbase app metadata was not found for existing version {app_version}."
                 )
-                return 1
 
             release_notes = get_release_notes(
                 app_version,
                 Path(os.environ["GITHUB_WORKSPACE"]) if os.getenv("GITHUB_WORKSPACE") else None,
             )
             if not release_notes:
-                logging.error("Could not find release notes for existing version %s", app_version)
-                return 1
+                return _fail(f"Release notes were not found for existing version {app_version}.")
 
             _write_github_outputs(
                 app_json,
@@ -296,12 +302,10 @@ def main(args):
             return 0
 
         if candidate_version <= latest_release:
-            logging.error(
-                "Candidate version %s must be greater than the latest released version %s",
-                app_version,
-                latest_release.public,
+            return _fail(
+                f"Candidate version {app_version} must be greater than the latest "
+                f"released version {latest_release.public}."
             )
-            return 1
     else:
         logging.info("Version %s will be the first release", app_version)
 
@@ -314,8 +318,9 @@ def main(args):
     if not release_notes:
         release_notes = get_release_notes_from_tarball(tarball, app_version)
     if not release_notes:
-        logging.error("Could not find release notes in tarball for version %s!", app_version)
-        return 1
+        return _fail(
+            f"Release notes for version {app_version} were not found in the workspace or package."
+        )
 
     logging.info("Found release notes for version %s: %s", app_version, release_notes)
 
@@ -408,6 +413,10 @@ def _record_upload_error(status: str, exc: SplunkbaseUploadError) -> int:
     _write_publish_result(
         status,
         **context,
+        failure_reason={
+            "permission_denied": "Splunkbase denied the upload request.",
+            "validation_failed": "Splunkbase rejected the upload request.",
+        }.get(status),
         message=str(exc),
         request_id=exc.request_id,
         retry_after=exc.retry_after,
@@ -432,7 +441,10 @@ def cli() -> int:
         if _existing_publish_result().get("status") == "verifying":
             logging.error("The upload was already accepted; preserving GET-only verification state")
             return RESULT_CODES["verifying"]
-        _write_publish_result("failed")
+        _write_publish_result(
+            "failed",
+            failure_reason="The publisher raised an unexpected error before completing.",
+        )
         return RESULT_CODES["failed"]
 
 

--- a/.github/actions/publish/upload_to_splunkbase.py
+++ b/.github/actions/publish/upload_to_splunkbase.py
@@ -34,6 +34,8 @@ NEW_APP_WARNING_MESSAGE = (
     "Please notify the Splunkbase team. "
     "See: http://go/new-soar-app-in-splunkbase for more."
 )
+LOG_FORMAT = "{asctime} - {levelname} - {message}"
+LOG_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 SPLUNKBASE_USER = os.getenv("SPLUNKBASE_USER")
 SPLUNKBASE_PASSWORD = os.getenv("SPLUNKBASE_PASSWORD")
@@ -50,6 +52,16 @@ RESULT_CODES = {
     "validation_failed": 13,
     "verifying": 14,
 }
+
+
+def configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format=LOG_FORMAT,
+        datefmt=LOG_DATE_FORMAT,
+        style="{",
+        force=True,
+    )
 
 
 def is_successful_rerun_of_existing_version(candidate_version, latest_release, run_attempt=None):
@@ -449,5 +461,5 @@ def cli() -> int:
 
 
 if __name__ == "__main__":
-    logging.getLogger().setLevel(logging.INFO)
+    configure_logging()
     sys.exit(cli())

--- a/.github/scripts/drain_splunkbase_publish_queue.py
+++ b/.github/scripts/drain_splunkbase_publish_queue.py
@@ -246,6 +246,7 @@ def block_publication(queue, item, result, reason, return_code=1) -> int:
     """Persist a terminal failure and expose sanitized notification fields."""
 
     result["worker_run_url"] = worker_run_url()
+    result["failure_reason"] = reason
     queue.block(item, result)
     write_output("publish_return_code", return_code)
     write_output("request_id", result.get("request_id", ""))
@@ -468,7 +469,7 @@ def publish_item(args) -> int:
         queue,
         item,
         result,
-        f"Publisher stopped with terminal status {status}.",
+        result.get("failure_reason") or f"Publisher stopped with terminal status {status}.",
         return_code=return_code,
     )
 

--- a/.github/scripts/drain_splunkbase_publish_queue_worker.py
+++ b/.github/scripts/drain_splunkbase_publish_queue_worker.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import timedelta
 import importlib.util
+import logging
 import os
 from pathlib import Path
 import subprocess
@@ -30,6 +31,8 @@ REPO_ROOT = SCRIPT_DIR.parent.resolve()
 MAX_RUN_SECONDS = 60 * 60
 MAX_UPLOAD_ATTEMPTS = 20
 LOG_SEPARATOR = "=" * 80
+LOG_FORMAT = "{asctime} - {levelname} - {message}"
+LOG_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 
 def load_module(name: str, path: Path):
@@ -43,6 +46,16 @@ DRAIN = load_module(
     "drain_splunkbase_publish_queue",
     SCRIPT_DIR / "drain_splunkbase_publish_queue.py",
 )
+
+
+def configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format=LOG_FORMAT,
+        datefmt=LOG_DATE_FORMAT,
+        style="{",
+        force=True,
+    )
 
 
 @dataclass
@@ -280,6 +293,7 @@ def drain_queue(_args) -> int:
 
 
 def main() -> int:
+    configure_logging()
     return drain_queue(SimpleNamespace())
 
 

--- a/.github/scripts/drain_splunkbase_publish_queue_worker.py
+++ b/.github/scripts/drain_splunkbase_publish_queue_worker.py
@@ -241,10 +241,7 @@ def drain_queue(_args) -> int:
     items_processed = 0
     had_failures = False
 
-    while (
-        time.monotonic() - started < MAX_RUN_SECONDS
-        and attempts_started < MAX_UPLOAD_ATTEMPTS
-    ):
+    while time.monotonic() - started < MAX_RUN_SECONDS and attempts_started < MAX_UPLOAD_ATTEMPTS:
         queue = DRAIN.queue_from_environment()
         item = queue.oldest_eligible("soar-connectors-default", DRAIN.utc_now())
         if item is None:

--- a/.github/scripts/drain_splunkbase_publish_queue_worker.py
+++ b/.github/scripts/drain_splunkbase_publish_queue_worker.py
@@ -29,6 +29,7 @@ SCRIPT_DIR = Path(__file__).parent.resolve()
 REPO_ROOT = SCRIPT_DIR.parent.resolve()
 MAX_RUN_SECONDS = 60 * 60
 MAX_UPLOAD_ATTEMPTS = 20
+LOG_SEPARATOR = "=" * 80
 
 
 def load_module(name: str, path: Path):
@@ -67,7 +68,7 @@ def run_checked(command: list[str], *, cwd: Path | None = None, env=None) -> Non
 
 
 def checkout_connector(repository: str, commit_sha: str, destination: Path) -> None:
-    run_checked(["git", "init", str(destination)])
+    run_checked(["git", "init", "--quiet", "--initial-branch=main", str(destination)])
     run_checked(
         [
             "git",
@@ -85,12 +86,13 @@ def checkout_connector(repository: str, commit_sha: str, destination: Path) -> N
             "-C",
             str(destination),
             "fetch",
+            "--quiet",
             "--depth=2",
             "origin",
             commit_sha,
         ]
     )
-    run_checked(["git", "-C", str(destination), "checkout", "--detach", "FETCH_HEAD"])
+    run_checked(["git", "-C", str(destination), "checkout", "--quiet", "--detach", "FETCH_HEAD"])
 
 
 def send_release_metrics(outputs: dict[str, str], connector: Path, temporary: Path) -> None:
@@ -249,10 +251,19 @@ def drain_queue(_args) -> int:
             break
 
         print(
-            f"Processing queue issue #{item.issue_number}: "
-            f"{item.repository} v{item.candidate_version}"
+            f"\n{LOG_SEPARATOR}\n"
+            f"Queue issue #{item.issue_number} | "
+            f"{item.repository} v{item.candidate_version}\n"
+            f"{LOG_SEPARATOR}",
+            flush=True,
         )
         outcome = process_item(queue, item, wait_until)
+        print(
+            f"{LOG_SEPARATOR}\n"
+            f"Finished {item.repository} v{item.candidate_version}: "
+            f"{outcome.queue_status}\n",
+            flush=True,
+        )
         attempts_started += outcome.attempts_started
         items_processed += 1
         had_failures = had_failures or outcome.failed

--- a/.github/scripts/notify_splunkbase_publish_failure.py
+++ b/.github/scripts/notify_splunkbase_publish_failure.py
@@ -24,12 +24,7 @@ def build_message(environment: dict[str, str]) -> str:
         lines.append(f"Splunkbase request ID: {request_id}")
     if package_id := environment.get("SPLUNKBASE_PACKAGE_ID"):
         lines.append(f"Splunkbase package ID: {package_id}")
-    lines.extend(
-        [
-            f"Reason: {environment['FAILURE_REASON']}",
-            "Automated by the Codex-authored Splunkbase publish queue.",
-        ]
-    )
+    lines.append(f"Reason: {environment['FAILURE_REASON']}")
     return "\n".join(lines)
 
 

--- a/.github/scripts/test_drain_splunkbase_publish_queue.py
+++ b/.github/scripts/test_drain_splunkbase_publish_queue.py
@@ -428,6 +428,35 @@ def test_pre_upload_metadata_failure_blocks_without_reserving_or_posting(monkeyp
     assert outputs["failure_reason"].startswith("Splunkbase app metadata")
 
 
+def test_terminal_publisher_diagnostic_is_preserved_in_issue_and_output(monkeypatch):
+    queue = Mock()
+    item = interrupted_item()
+    item.attempts = []
+    queue.get_item.return_value = item
+    queue.reserve_attempt.return_value = None
+    client = Mock()
+    client.get_existing_releases.return_value = []
+    client.get_apps.return_value = []
+    reason = "Candidate version 1.0.0 must be greater than the latest released version 1.0.0."
+    monkeypatch.setattr(MODULE, "queue_from_environment", lambda: queue)
+    monkeypatch.setattr(MODULE, "Splunkbase", lambda *args, **kwargs: client)
+    monkeypatch.setattr(
+        MODULE,
+        "run_publisher",
+        lambda args, item: (1, {"status": "failed", "failure_reason": reason}),
+    )
+    outputs = {}
+    monkeypatch.setattr(MODULE, "write_output", outputs.__setitem__)
+    monkeypatch.setenv("SPLUNKBASE_USER", "publisher")
+    monkeypatch.setenv("SPLUNKBASE_PASSWORD", "password")
+
+    assert MODULE.publish_item(finalization_args()) == 1
+
+    blocked_result = queue.block.call_args.args[1]
+    assert blocked_result["failure_reason"] == reason
+    assert outputs["failure_reason"] == reason
+
+
 def test_continued_pending_validation_does_not_post_or_reserve(monkeypatch):
     queue = Mock()
     client = Mock()

--- a/.github/scripts/test_drain_splunkbase_publish_queue_worker.py
+++ b/.github/scripts/test_drain_splunkbase_publish_queue_worker.py
@@ -31,6 +31,21 @@ def queue_with_items(count):
     return queue
 
 
+def test_worker_logging_uses_only_time_level_and_message(monkeypatch):
+    basic_config = Mock()
+    monkeypatch.setattr(MODULE.logging, "basicConfig", basic_config)
+
+    MODULE.configure_logging()
+
+    basic_config.assert_called_once_with(
+        level=MODULE.logging.INFO,
+        format="{asctime} - {levelname} - {message}",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        style="{",
+        force=True,
+    )
+
+
 def test_connector_checkout_suppresses_routine_git_output(tmp_path, monkeypatch):
     run_checked = Mock()
     destination = tmp_path / "connector"

--- a/.github/scripts/test_drain_splunkbase_publish_queue_worker.py
+++ b/.github/scripts/test_drain_splunkbase_publish_queue_worker.py
@@ -31,6 +31,55 @@ def queue_with_items(count):
     return queue
 
 
+def test_connector_checkout_suppresses_routine_git_output(tmp_path, monkeypatch):
+    run_checked = Mock()
+    destination = tmp_path / "connector"
+    monkeypatch.setattr(MODULE, "run_checked", run_checked)
+
+    MODULE.checkout_connector(
+        "splunk-soar-connectors/example",
+        "abc123",
+        destination,
+    )
+
+    commands = [call.args[0] for call in run_checked.call_args_list]
+    assert commands[0] == [
+        "git",
+        "init",
+        "--quiet",
+        "--initial-branch=main",
+        str(destination),
+    ]
+    assert "--quiet" in commands[2]
+    assert "--quiet" in commands[3]
+
+
+def test_worker_log_separates_repository_results(monkeypatch, capsys):
+    queue = queue_with_items(1)
+    process_item = Mock(
+        return_value=MODULE.ItemOutcome(
+            queue_status="blocked",
+            attempts_started=0,
+            failed=True,
+        )
+    )
+    monkeypatch.setattr(MODULE.DRAIN, "queue_from_environment", lambda: queue)
+    monkeypatch.setattr(MODULE, "process_item", process_item)
+    monkeypatch.setattr(MODULE.time, "monotonic", lambda: 0)
+
+    assert MODULE.drain_queue(SimpleNamespace()) == 1
+
+    output = capsys.readouterr().out
+    assert (
+        f"{MODULE.LOG_SEPARATOR}\n"
+        "Queue issue #1 | splunk-soar-connectors/example-1 v1.0.0\n"
+        f"{MODULE.LOG_SEPARATOR}"
+    ) in output
+    assert (
+        f"{MODULE.LOG_SEPARATOR}\nFinished splunk-soar-connectors/example-1 v1.0.0: blocked"
+    ) in output
+
+
 def test_drain_stops_after_twenty_started_upload_attempts(monkeypatch):
     queue = queue_with_items(MODULE.MAX_UPLOAD_ATTEMPTS + 1)
     process_item = Mock(

--- a/.github/scripts/test_notify_splunkbase_publish_failure.py
+++ b/.github/scripts/test_notify_splunkbase_publish_failure.py
@@ -25,7 +25,7 @@ def environment(**overrides):
     return values
 
 
-def test_message_contains_tracking_fields_and_codex_attribution():
+def test_message_contains_tracking_fields_and_failure_reason():
     message = MODULE.build_message(environment())
 
     assert "splunk-soar-connectors/example v1.2.3" in message
@@ -37,7 +37,8 @@ def test_message_contains_tracking_fields_and_codex_attribution():
         "<https://github.com/splunk-soar-connectors/.github/actions/runs/12345"
         "|open failed worker run>"
     ) in message
-    assert "Codex-authored" in message
+    assert "Reason: Splunkbase definitively rejected the package." in message
+    assert "Codex" not in message
 
 
 def test_message_omits_splunkbase_ids_before_an_upload():

--- a/.github/utils/publish_queue.py
+++ b/.github/utils/publish_queue.py
@@ -27,9 +27,9 @@ MAX_ATTEMPTS_PER_HOUR = 20
 MIN_ATTEMPT_INTERVAL = timedelta(minutes=3)
 
 LABELS = {
-    QUEUE_MARKER: ("5319e7", "Managed by Codex-authored Splunkbase queue automation."),
+    QUEUE_MARKER: ("5319e7", "Managed by Splunkbase queue automation."),
     QUEUE_STATES["queued"]: ("fbca04", "Waiting for the shared Splunkbase publishing user."),
-    QUEUE_STATES["active"]: ("1d76db", "A Codex-authored worker is processing this publication."),
+    QUEUE_STATES["active"]: ("1d76db", "A worker is processing this publication."),
     QUEUE_STATES["verifying"]: (
         "bfd4f2",
         "Splunkbase accepted the upload; only GET reconciliation is permitted.",
@@ -37,7 +37,7 @@ LABELS = {
     QUEUE_STATES["rate_limited"]: ("d93f0b", "Splunkbase asked the shared user to wait."),
     QUEUE_STATES["blocked"]: ("b60205", "Publication needs human intervention."),
     QUEUE_STATES["published"]: ("0e8a16", "The connector version is present on Splunkbase."),
-    STATE_LABEL: ("c5def5", "Rate ledger for the Codex-authored Splunkbase queue."),
+    STATE_LABEL: ("c5def5", "Rate ledger for the Splunkbase queue."),
 }
 PUBLIC_RESULT_FIELDS = {
     "app_existed_before_upload",
@@ -49,6 +49,7 @@ PUBLIC_RESULT_FIELDS = {
     "package_id",
     "splunkbase_app_id",
     "worker_run_url",
+    "failure_reason",
 }
 
 
@@ -149,7 +150,7 @@ class GitHubClient:
                 "Accept": "application/vnd.github+json",
                 "Authorization": f"Bearer {token}",
                 "X-GitHub-Api-Version": "2022-11-28",
-                "User-Agent": "Splunk-SOAR-Publish-Queue/1.0 (Codex-authored)",
+                "User-Agent": "Splunk-SOAR-Publish-Queue/1.0",
             }
         )
 
@@ -187,7 +188,7 @@ class GitHubClient:
 def _encode_body(item: PublishQueueItem, note: str | None = None) -> str:
     note_text = f"\n\nStatus note: {note}" if note else ""
     return (
-        "Created and managed by Codex-authored Splunkbase queue automation."
+        "Created and managed by Splunkbase queue automation."
         f"{note_text}\n\n{BODY_START}\n"
         f"{json.dumps(item.as_dict(), indent=2, sort_keys=True)}\n"
         f"{BODY_END}\n"
@@ -442,12 +443,10 @@ class GitHubIssuePublishQueue:
         else:
             item.attempts.append(public_result)
         worker_run_url = public_result.get("worker_run_url")
-        note = "Publication stopped without an automatic retry; inspect the worker log."
+        reason = public_result.get("failure_reason")
+        note = reason or "Publication stopped without an automatic retry."
         if worker_run_url:
-            note = (
-                "Publication stopped without an automatic retry; inspect the "
-                f"[failed worker run]({worker_run_url})."
-            )
+            note = f"{note} See the [worker run]({worker_run_url})."
         self._update(
             item,
             state="blocked",
@@ -465,7 +464,7 @@ class GitHubIssuePublishQueue:
             json={
                 "title": title,
                 "body": (
-                    "Managed by Codex-authored Splunkbase queue automation.\n\n"
+                    "Managed by Splunkbase queue automation.\n\n"
                     f"{BODY_START}\n"
                     f"{json.dumps({'publisher_alias': publisher_alias, 'attempts': []}, indent=2)}\n"
                     f"{BODY_END}\n"
@@ -513,7 +512,7 @@ class GitHubIssuePublishQueue:
         )
         state["attempts"] = attempts
         state_body = (
-            "Managed by Codex-authored Splunkbase queue automation.\n\n"
+            "Managed by Splunkbase queue automation.\n\n"
             f"{BODY_START}\n{json.dumps(state, indent=2, sort_keys=True)}\n{BODY_END}\n"
         )
         self.client.request(

--- a/.github/utils/test_publish_queue.py
+++ b/.github/utils/test_publish_queue.py
@@ -93,7 +93,7 @@ def test_queue_body_round_trip_preserves_dedupe_fields():
 
     assert decoded.dedupe_key == item.dedupe_key
     assert decoded.asset_name == item.asset_name
-    assert "Codex-authored" in _encode_body(item)
+    assert "Created and managed by Splunkbase queue automation." in _encode_body(item)
 
 
 def test_duplicate_enqueue_reuses_one_issue():
@@ -257,6 +257,9 @@ def test_blocked_issue_does_not_publish_raw_response_text():
             "worker_run_url": (
                 "https://github.com/splunk-soar-connectors/.github/actions/runs/12345"
             ),
+            "failure_reason": (
+                "Candidate version 1.0.0 must be greater than the latest released version 1.0.0."
+            ),
             "message": "internal Splunkbase response details",
         },
     )
@@ -264,7 +267,8 @@ def test_blocked_issue_does_not_publish_raw_response_text():
     body = client.issues[0]["body"]
     assert "validation_failed" in body
     assert "request-123" in body
+    assert "Candidate version 1.0.0 must be greater than the latest released version 1.0.0." in body
     assert (
-        "[failed worker run](https://github.com/splunk-soar-connectors/.github/actions/runs/12345)"
+        "[worker run](https://github.com/splunk-soar-connectors/.github/actions/runs/12345)"
     ) in body
     assert "internal Splunkbase response details" not in body


### PR DESCRIPTION
### Bug Fixes

- Preserve controlled, connector-specific publisher diagnostics in blocked queue issues and Slack warnings. The ArcSight failure would now surface: `Candidate version 1.0.0 must be greater than the latest released version 1.0.0.`
- Keep arbitrary Splunkbase response bodies out of public queue issues while retaining the bulk worker run as supporting context.
- Remove Codex attribution from runtime-generated queue messages, label descriptions, and artifact notes.
- Suppress routine Git checkout output and bracket each connector publication with visible start and completion separators.
- Format worker and publisher log records as `{time} - {level} - {message}` using Python's `asctime`, `levelname`, and `message` fields.

### Validation

- `uv run --with pytest --with backoff --with 'cairosvg==2.7.0' --with 'jinja2==3.1.5' --with packaging --with requests --with slack-sdk pytest -q .github/actions/publish/test_upload_to_splunkbase.py .github/scripts/test_drain_splunkbase_publish_queue.py .github/scripts/test_drain_splunkbase_publish_queue_worker.py .github/scripts/test_notify_splunkbase_publish_failure.py .github/utils/test_publish_queue.py .github/test_publish_workflow.py` (78 passed)
- `pre-commit run --all-files`
- `git diff --check`

No manual documentation changes are required.

Written by Codex.
