### PR TITLE
chore: run Splunkbase queue hourly

### DIFF
--- a/.github/test_publish_workflow.py
+++ b/.github/test_publish_workflow.py
@@ -45,6 +45,12 @@ def test_drain_is_bounded_to_one_hour_and_twenty_upload_attempts():
     assert "attempts_started < MAX_UPLOAD_ATTEMPTS" in worker
 
 
+def test_drain_runs_once_per_hour():
+    workflow = DRAIN_WORKFLOW.read_text()
+
+    assert 'cron: "0 * * * *"' in workflow
+
+
 def test_skipped_direct_publish_cannot_trigger_release_slack():
     workflow = WORKFLOW.read_text()
     notify = workflow.split("\n  notify-slack:\n", 1)[1]

--- a/.github/workflows/drain-splunkbase-publish-queue.yml
+++ b/.github/workflows/drain-splunkbase-publish-queue.yml
@@ -2,7 +2,7 @@ name: Drain Splunkbase publish queue
 
 on:
   schedule:
-    - cron: "*/5 * * * *"
+    - cron: "0 * * * *"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
### Bug Fixes

- Change the bounded Splunkbase queue drain schedule from every five minutes to once per hour at minute zero.
- Preserve `workflow_dispatch` for manual queue drains.
- Add a workflow test that locks in the hourly schedule.

### Validation

- `uv run --with pytest pytest -q .github/test_publish_workflow.py` (9 passed)
- `pre-commit run --files .github/workflows/drain-splunkbase-publish-queue.yml .github/test_publish_workflow.py`
- `git diff --check`

No manual documentation changes are required.

Written by Codex.