### PR TITLE
fix: restore reusable push workflow trigger

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,7 @@
 name: Reusable Push Workflow
 
 on:
+  workflow_call:
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
## Summary

- restore the `workflow_call` trigger on the shared push workflow
- retain `pull_request_target` for direct execution in the shared repository

## Why

Connector repositories invoke `.github/workflows/push.yml` as a reusable workflow. Without `on.workflow_call`, GitHub rejects connector PR workflows before any jobs or app tests can run.

The Zscaler v2 app ID is already registered on current `main`, so the rebased branch intentionally contains only this workflow correction.

## Validation

- shared repository pre-commit hooks pass for `.github/workflows/push.yml`
- `git diff --check` passes