### PR TITLE
chore: register analyst1 app name in registry mappings

### DIFF
--- a/.github/data/appid_to_name.json
+++ b/.github/data/appid_to_name.json
@@ -295,6 +295,7 @@
     "8e235e70-57eb-4292-9b7c-6cc44847d837": "Sumo Logic",
     "8e8be6eb-a509-45ca-8559-586cb592a6d8": "AWS Security Token Service",
     "8eca4888-4d1c-4310-bb0c-70136109cb4c": "AWS Athena",
+    "8ee822f1-a285-44f4-b8e7-303245811a32": "Analyst1 for Splunk SOAR",
     "8f9e2a5c-b1d4-4e7a-9c3f-6b8d5a2e4f71": "Cyberint IoC",
     "906542d8-1279-4629-a027-1f3c1e501ecc": "Fresh Service",
     "90a76493-0c71-4cb0-b5de-f66afe1c8cd7": "Cloaken",


### PR DESCRIPTION
Adds the Analyst1 SOAR connector to `.github/data/appid_to_name.json` under its new name, "Analyst1 for Splunk SOAR". App id `8ee822f1-a285-44f4-b8e7-303245811a32`.

Splunkbase already lists an app named "Analyst1", which is the Analyst1 add-on for Splunk Enterprise and a separate product. The SOAR connector is being renamed to avoid the collision. Context is in splunk-soar-connectors/analyst1#3, where @athreya-splunk asked for this change.

Note this file and `local_hooks/data/appid_to_name.json` in phantomcyber/dev-cicd-tools are currently out of sync by one entry each. This app id is present only in the dev-cicd-tools copy, and `46615e8c-69dd-4b8f-94d1-290efa867143` (WMI) is present only here. That is why this is an addition rather than an edit. The matching rename in dev-cicd-tools is phantomcyber/dev-cicd-tools#256.