### PR TITLE
fix: support current urllib3 retry configuration

### DIFF
--- a/.github/utils/api/__init__.py
+++ b/.github/utils/api/__init__.py
@@ -22,7 +22,7 @@ class ApiSession(requests.Session):
             total=5,
             backoff_factor=1,
             status_forcelist=[408, 409, 500, 502, 503, 504],
-            method_whitelist=["GET", "POST"],
+            allowed_methods=frozenset(["GET", "POST"]),
             raise_on_status=False,
         )
         self.mount(self.base_url, HTTPAdapter(max_retries=retry_strategy))

--- a/.github/utils/api/test_api_session.py
+++ b/.github/utils/api/test_api_session.py
@@ -1,0 +1,8 @@
+from . import ApiSession
+
+
+def test_api_session_retries_gets_and_posts():
+    session = ApiSession("https://example.com")
+    retry = session.get_adapter("https://example.com").max_retries
+
+    assert retry.allowed_methods == frozenset(["GET", "POST"])


### PR DESCRIPTION
### Bug Fixes

- Replace the removed `Retry.method_whitelist` argument with `allowed_methods` so traditional connector builds work with current urllib3 releases.
- Add regression coverage for GET/POST retry configuration.

### Manual Documentation

- [x] No manual documentation changes are required.

### Verification

- `uv run --with pytest --with requests --with backoff pytest .github/utils/api/test_api_session.py .github/utils/api/test_splunkbase.py` — 17 passed.
- All non-Docker pre-commit hooks passed; the Docker-backed ShellCheck hook could not run because the local Docker daemon is unavailable.

This PR was authored by Codex for Scott Dole.