### PR TITLE
fix: pass Conjur credentials to app tests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -331,6 +331,9 @@ jobs:
         shell: bash
 
       - name: Run Test Coverage
+        env:
+          CONJUR_AUTHN_LOGIN: ${{ secrets.CONJUR_AUTHN_LOGIN }}
+          CONJUR_AUTHN_API_KEY: ${{ secrets.CONJUR_AUTHN_API_KEY }}
         uses: splunk-soar-connectors/.github/.github/actions/test-coverage@main
         with:
           app_repo: ${{ github.event.repository.name }}
@@ -387,6 +390,9 @@ jobs:
 
       - name: Run Sanity Tests
         if: steps.version-check.outputs.compatible == 'true'
+        env:
+          CONJUR_AUTHN_LOGIN: ${{ secrets.CONJUR_AUTHN_LOGIN }}
+          CONJUR_AUTHN_API_KEY: ${{ secrets.CONJUR_AUTHN_API_KEY }}
         uses: splunk-soar-connectors/.github/.github/actions/sanity-tests@main
         with:
           phantom_ip: ${{ matrix.ip }}
@@ -449,6 +455,9 @@ jobs:
           name: app-tar
 
       - name: Run Sanity Tests
+        env:
+          CONJUR_AUTHN_LOGIN: ${{ secrets.CONJUR_AUTHN_LOGIN }}
+          CONJUR_AUTHN_API_KEY: ${{ secrets.CONJUR_AUTHN_API_KEY }}
         uses: splunk-soar-connectors/.github/.github/actions/sanity-tests@main
         with:
           phantom_ip: ${{ steps.resolve-ip.outputs.ip }}
@@ -500,6 +509,9 @@ jobs:
           name: app-tar
 
       - name: Run Integration Tests
+        env:
+          CONJUR_AUTHN_LOGIN: ${{ secrets.CONJUR_AUTHN_LOGIN }}
+          CONJUR_AUTHN_API_KEY: ${{ secrets.CONJUR_AUTHN_API_KEY }}
         uses: splunk-soar-connectors/.github/.github/actions/integration-tests@main
         with:
           fips_compliant: ${{ needs.test-setup.outputs.fips_compliant }}


### PR DESCRIPTION
## Summary

- expose the Conjur authentication login and API key to app-tests through step-scoped environment variables
- cover test coverage, standard sanity, AWS sanity, and integration test invocations
- avoid exposing the credentials to unrelated workflow steps

## Root cause

Organization-level GitHub Actions secrets are available through the `secrets` context but are not automatically exported into the runner environment. The app-tests Conjur reader requires `CONJUR_AUTHN_LOGIN` and `CONJUR_AUTHN_API_KEY` in `os.environ`, so the tests failed before reading asset credentials.

## Validation

- `git diff --check`
- `pre-commit run check-yaml --files .github/workflows/push.yml`
- Ruby YAML parse
