### PR TITLE
fix: pin compatible conventional changelog preset

### DIFF
--- a/.github/test_publish_workflow.py
+++ b/.github/test_publish_workflow.py
@@ -2,12 +2,19 @@ from pathlib import Path
 
 
 WORKFLOW = Path(__file__).parent / "workflows" / "publish.yml"
+PUSH_WORKFLOW = Path(__file__).parent / "workflows" / "push.yml"
 DRAIN_WORKFLOW = Path(__file__).parent / "workflows" / "drain-splunkbase-publish-queue.yml"
 ENQUEUE_WORKFLOW = Path(__file__).parent / "workflows" / "enqueue-splunkbase-publish.yml"
 ENQUEUE_ACTION = Path(__file__).parent / "actions" / "enqueue-publish" / "action.yml"
 NOTIFY_ACTION = Path(__file__).parent / "actions" / "notify-slack" / "action.yml"
 NOTIFY_SCRIPT = Path(__file__).parent / "actions" / "notify-slack" / "notify_slack.py"
 QUEUE_WORKER = Path(__file__).parent / "scripts" / "drain_splunkbase_publish_queue_worker.py"
+
+
+def test_semantic_release_uses_compatible_conventional_commits_preset():
+    workflow = PUSH_WORKFLOW.read_text()
+
+    assert "conventional-changelog-conventionalcommits@9.3.1" in workflow
 
 
 def test_enqueue_uses_the_commit_that_created_the_artifact():

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -127,7 +127,12 @@ jobs:
           node-version: "24"
 
       - name: Install semantic-release dependencies
-        run: npm install --global semantic-release @semantic-release/exec @semantic-release/git conventional-changelog-conventionalcommits
+        run: |
+          npm install --global \
+            semantic-release \
+            @semantic-release/exec \
+            @semantic-release/git \
+            conventional-changelog-conventionalcommits@9.3.1
 
       - name: Prepare release configuration
         run: |


### PR DESCRIPTION
### Bug Fixes

- Pin `conventional-changelog-conventionalcommits` to `9.3.1`, the version tested by `@semantic-release/release-notes-generator` 14.x with `conventional-changelog-writer` 8.x.
- Prevent the newly released preset 10.4.0 from breaking semantic-release preview jobs during release-note generation.
- Add regression coverage to keep the compatible preset pinned.

### Manual Documentation

- [x] I have verified that manual documentation has been updated where appropriate. No manual documentation changes are needed for this CI-only fix.

### Testing

- `python -m pytest -q .github/test_publish_workflow.py` (`10 passed`)
- `pre-commit run --files .github/workflows/push.yml .github/test_publish_workflow.py`

### Other information

Observed in splunk-soar-connectors/splunk#92: https://github.com/splunk-soar-connectors/splunk/actions/runs/32498214784/job/96821595217

The failing job correctly selected version 4.0.1, then failed in `@semantic-release/release-notes-generator` because preset 10.4.0 requires `conventional-changelog-writer` 9 or newer while release-notes-generator 14.x currently loads writer 8.x.
