### PR TITLE
fix: pin conventional commits preset in publish workflow

### DIFF
--- a/.github/test_publish_workflow.py
+++ b/.github/test_publish_workflow.py
@@ -12,9 +12,10 @@ QUEUE_WORKER = Path(__file__).parent / "scripts" / "drain_splunkbase_publish_que
 
 
 def test_semantic_release_uses_compatible_conventional_commits_preset():
-    workflow = PUSH_WORKFLOW.read_text()
+    for workflow_path in (WORKFLOW, PUSH_WORKFLOW):
+        workflow = workflow_path.read_text()
 
-    assert "conventional-changelog-conventionalcommits@9.3.1" in workflow
+        assert "conventional-changelog-conventionalcommits@9.3.1" in workflow
 
 
 def test_enqueue_uses_the_commit_that_created_the_artifact():

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
         - name: Install dependencies
           run: |
             npm install --save-dev semantic-release
-            npm install @semantic-release/changelog @semantic-release/git @semantic-release/exec conventional-changelog-conventionalcommits -D
+            npm install @semantic-release/changelog @semantic-release/git @semantic-release/exec conventional-changelog-conventionalcommits@9.3.1 -D
             pip install tomlkit
 
         - name: Run semantic-release and update version numbers


### PR DESCRIPTION
## Summary

- pin `conventional-changelog-conventionalcommits` to `9.3.1` in the reusable publish workflow
- extend the semantic-release regression test to cover both `push.yml` and `publish.yml`

## Why

The publish workflow installed the latest conventional-commits preset, which is incompatible with the older `conventional-changelog-writer` loaded by the current semantic-release dependency graph. Semantic-release selected the next version successfully but failed while generating release notes.

## Testing

- `python -m pytest .github/test_publish_workflow.py` (10 passed)
- `ruff check .github/test_publish_workflow.py`
- `ruff format --check .github/test_publish_workflow.py`
- `git diff --check`

The local pre-commit wrapper could not provision its Ruff environment because the configured Artifactory credentials returned HTTP 401; the equivalent Ruff checks passed directly.